### PR TITLE
2 More fixes to CCR xml generation

### DIFF
--- a/lib/health-data-standards/export/ccr.rb
+++ b/lib/health-data-standards/export/ccr.rb
@@ -326,7 +326,7 @@ module HealthDataStandards
             end
             xml.DateOfBirth do
               xml.ExactDateTime(convert_to_ccr_time_string(patient.birthdate))
-                if (patient.gender)
+              if (patient.gender)
                 xml.Gender do
                   if (patient.gender.upcase == "M")
                     xml.Text("Male")

--- a/lib/health-data-standards/export/ccr.rb
+++ b/lib/health-data-standards/export/ccr.rb
@@ -46,10 +46,10 @@ module HealthDataStandards
       private
 
       def code_section(xml, codes)
-        xml.Code do
-          if codes.present?
-            codes.each_pair do |code_set, coded_values|
-              coded_values.each do |coded_value|
+        if codes.present?
+          codes.each_pair do |code_set, coded_values|
+            coded_values.each do |coded_value|
+              xml.Code do
                 xml.Value(coded_value)
                 xml.CodingSystem(code_set)
                 #TODO: Need to fix this and not be a hard-coded value

--- a/lib/health-data-standards/export/ccr.rb
+++ b/lib/health-data-standards/export/ccr.rb
@@ -323,9 +323,9 @@ module HealthDataStandards
                   xml.Family(patient.last)
                 end
               end
-            end
-            xml.DateOfBirth do
-              xml.ExactDateTime(convert_to_ccr_time_string(patient.birthdate))
+              xml.DateOfBirth do
+                xml.ExactDateTime(convert_to_ccr_time_string(patient.birthdate))
+              end
               if (patient.gender)
                 xml.Gender do
                   if (patient.gender.upcase == "M")


### PR DESCRIPTION
I noticed 2 other problems with the CCR-generation routine:
- The `<Code>` node is being misused.  More here: https://groups.google.com/forum/#!topic/project-cypress-dev/OwzYc9DIj1s.  Commit 3e65c77 repeats a `<Code>` node for each code
- The nodes inside `<Actor>` are all jumbled up.  Commit 78df002 properly organizes `<Gender>` and `<DateOfBirth>`
