### PR TITLE
Oh, valid CCR's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage*
+test/xsd

--- a/lib/health-data-standards/export/ccr.rb
+++ b/lib/health-data-standards/export/ccr.rb
@@ -29,13 +29,14 @@ module HealthDataStandards
           to_ccr_purpose(xml)
           xml.Body do
             to_ccr_problems(xml, patient)
-            to_ccr_vitals(xml, patient)
-            to_ccr_results(xml, patient)
-            to_ccr_encounters(xml, patient)
+            to_ccr_allergies(xml, patient)
             to_ccr_medications(xml, patient)
             to_ccr_immunizations(xml, patient)
+            to_ccr_vitals(xml, patient)
+            to_ccr_results(xml, patient) 
             to_ccr_procedures(xml, patient)
-            to_ccr_allergies(xml, patient)
+            to_ccr_encounters(xml, patient)
+            
           end
           to_ccr_actors(xml, patient)
         end
@@ -283,6 +284,7 @@ module HealthDataStandards
                 xml.Status do
                   xml.Text("Active")
                 end
+                xml.Source
               end
             end
           end
@@ -312,6 +314,7 @@ module HealthDataStandards
                 xml.Status do
                   xml.Text("Current")
                 end
+                xml.Source
               end
             end
           end
@@ -347,6 +350,7 @@ module HealthDataStandards
                 end
               end
             end
+             xml.Source
           end
         end
       end

--- a/lib/health-data-standards/export/ccr.rb
+++ b/lib/health-data-standards/export/ccr.rb
@@ -70,15 +70,7 @@ module HealthDataStandards
           end
         end
       end
-      
-      def test_result_section(xml, test_result)
-        xml.TestResult do
-          xml.Value(test_result.value["scalar"])
-          xml.Units do
-            xml.Unit(test_result.value["units"])
-          end          
-        end  
-      end
+
 
       # Builds the XML snippet for the problems section inside the CCR standard
       #
@@ -145,26 +137,57 @@ module HealthDataStandards
         if patient.vital_signs.present?
           xml.VitalSigns do
             patient.vital_signs.each_with_index do |vital_sign, index|
-              xml.Result do
-                xml.CCRDataObjectID("VT000#{index + 1}")
-                xml.DateTime do
-                  xml.Type do
-                    xml.Text("Start date")
-                  end
-                  #time
-                  xml.ExactDateTime(convert_to_ccr_time_string(vital_sign.time))
-                end
-                xml.Description do
-                  xml.Text(vital_sign.description)
-                  code_section(xml, vital_sign.codes)
-                  test_result_section(xml,vital_sign)
-                end
-              end
+              to_result(xml,vital_sign,"VT000#{index + 1}")
             end
           end
         end
       end
 
+
+      # Builds the XML snippet for the lab section inside the CCR standard
+      #
+      # @return [Builder::XmlMarkup] CCR XML representation of patient data
+      def to_ccr_results(xml, patient)
+        if patient.results.present?
+          xml.Results do
+            patient.results.each_with_index do |lab_result, index|
+              to_result(xml,lab_result,"LB000#{index + 1}")
+            end
+          end
+        end
+      end
+      
+
+     def to_result(xml, res, ccr_id )
+       xml.Result do
+         xml.CCRDataObjectID(ccr_id)
+         xml.DateTime do
+           xml.Type do
+             xml.Text("Start date")
+           end
+           #time
+           xml.ExactDateTime(convert_to_ccr_time_string(res.time))
+         end
+         xml.Description do
+           xml.Text(res.description)
+           code_section(xml, res.codes)
+         end
+         
+         xml.Source
+         xml.Test do
+           xml.CCRDataObjectID("#{ccr_id}TestResult")
+           xml.Source
+           xml.TestResult do
+             xml.Value(res.value["scalar"])
+             xml.Units do
+               xml.Unit(res.value["units"])
+             end          
+           end
+        end
+       end
+       
+     end
+     
       # Builds the XML snippet for the medications section inside the CCR standard
       #
       # @return [Builder::XmlMarkup] CCR XML representation of patient data
@@ -235,32 +258,7 @@ module HealthDataStandards
         end
       end
 
-      # Builds the XML snippet for the lab section inside the CCR standard
-      #
-      # @return [Builder::XmlMarkup] CCR XML representation of patient data
-      def to_ccr_results(xml, patient)
-        if patient.results.present?
-          xml.Results do
-            patient.results.each_with_index do |lab_result, index|
-              xml.Result do
-                xml.CCRDataObjectID("LB000#{index + 1}")
-                xml.DateTime do
-                  xml.Type do
-                    xml.Text("Start date")
-                  end
-                  #time
-                  xml.ExactDateTime(convert_to_ccr_time_string(lab_result.time))
-                end
-                xml.Description do
-                  xml.Text(lab_result.description)
-                  code_section(xml, lab_result.codes)
-                  test_result_section(xml,lab_result)
-                end
-              end
-            end
-          end
-        end
-      end
+      
 
       # Builds the XML snippet for the procedures section inside the CCR standard
       #

--- a/test/unit/export/ccr_test.rb
+++ b/test/unit/export/ccr_test.rb
@@ -6,8 +6,15 @@ class CCRTest < MiniTest::Unit::TestCase
     record = Record.find('4dcbecdb431a5f5878000004')
 
     doc = Nokogiri::XML(HealthDataStandards::Export::CCR.export(record))
+    
+    #this will only run if there is an environment variable set to point to the 
+    #schema location.  Cant be pushing the schema to github ya know . 
+    if ENV['CCR_SCHEMA']
+      xsd = Nokogiri::XML::Schema(open(ENV['CCR_SCHEMA']))
+      assert_equal [], xsd.validate(doc) 
+    end  
     doc.root.add_namespace_definition('ccr', 'urn:astm-org:CCR')
-  
+    
   # registration information
     assert_equal 'Rosa', doc.at_xpath('//ccr:Actors/ccr:Actor/ccr:Person/ccr:Name/ccr:CurrentName/ccr:Given').text
     assert_equal 'Vasquez', doc.at_xpath('//ccr:Actors/ccr:Actor/ccr:Person/ccr:Name/ccr:CurrentName/ccr:Family').text


### PR DESCRIPTION
Cleaned up the ccr exporter to produce valid ccr files.  Also added hook to allow the tests to validate ccr documents against the ccr schema.  This will need to be made available via an environment variable seeing how we cannot push the schema out due to licensing restrictions.  
