### PR TITLE
Develop

### DIFF
--- a/lib/health-data-standards/export/view_helper.rb
+++ b/lib/health-data-standards/export/view_helper.rb
@@ -53,6 +53,20 @@ module HealthDataStandards
       def time_if_not_nil(*args)
         args.compact.map {|t| Time.at(t).utc}.first
       end
+      
+      def is_num?(str)
+        puts str.nil? ? "IS NIL" : "IS NOT NIL"
+        Float(str || "")
+      rescue ArgumentError
+        false
+      else
+        true
+      end
+      
+      def is_bool?(str)
+        puts (["true","false"].include? (str || "").downcase) ? "IS bool " : "IS NOT bool"
+        return ["true","false"].include? (str || "").downcase
+      end
     end
   end
 end

--- a/lib/health-data-standards/import/c32/section_importer.rb
+++ b/lib/health-data-standards/import/c32/section_importer.rb
@@ -133,9 +133,11 @@ module HealthDataStandards
           if value_element
             value = value_element['value']
             unit = value_element['unit']
+            value ||= value_element.text 
             if value
-              entry.set_value(value, unit)
+              entry.set_value(value.strip, unit)
             end
+            
           end
         end
         

--- a/templates/_results.c32.erb
+++ b/templates/_results.c32.erb
@@ -45,8 +45,14 @@
             </text>
             <statusCode code="completed"/>
             <effectiveTime <%= value_or_null_flavor(entry.as_point_in_time) %>/>
-            <% if entry.value -%>
-            <value xsi:type="PQ" value="<%= entry.value["scalar"] %>" <% if entry.value["units"]-%>unit="<%= entry.value["units"] %>"<% end -%>/>
+       		 <% if entry.value -%>
+			   <% if is_num?(entry.value['scalar']) -%>
+                <value xsi:type="PQ" value="<%= entry.value["scalar"] %>" <% if entry.value["units"]-%>unit="<%= entry.value["units"] %>"<% end -%>/>
+	           <% elsif is_bool?(entry.value['scalar'])%>
+				 <value xsi:type="BL" value="<%= entry.value["scalar"] %>" />
+	         <% else -%>
+	            <value xsi:type="ST" ><%= entry.value["scalar"] %></value> 
+	         <% end -%>
             <% else -%>
             <value xsi:type="PQ" nullFlavor="UNK"/>
             <% end -%>

--- a/templates/_vital_signs.c32.erb
+++ b/templates/_vital_signs.c32.erb
@@ -35,7 +35,13 @@
             <statusCode code="completed"/>
             <effectiveTime <%= value_or_null_flavor(entry.as_point_in_time) %>/>
             <% if entry.value -%>
-            <value xsi:type="PQ" value="<%= entry.value["scalar"] %>" <% if entry.value["units"]-%>unit="<%= entry.value["units"] %>"<% end -%>/>
+			   <% if is_num?(entry.value['scalar']) -%>
+                <value xsi:type="PQ" value="<%= entry.value["scalar"] %>" <% if entry.value["units"]-%>unit="<%= entry.value["units"] %>"<% end -%>/>
+	           <% elsif is_bool?(entry.value['scalar'])%>
+				 <value xsi:type="BL" value="<%= entry.value["scalar"] %>" />
+	         <% else -%>
+	            <value xsi:type="ST" ><%= entry.value["scalar"] %></value> 
+	         <% end -%>
             <% else -%>
             <value xsi:type="PQ" nullFlavor="UNK"/>
             <% end -%>

--- a/templates/show.c32.erb
+++ b/templates/show.c32.erb
@@ -6,7 +6,7 @@
   <templateId root="2.16.840.1.113883.10.20.3" assigningAuthorityName="HL7/CDT Header"/>
   <templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.1" assigningAuthorityName="IHE/PCC"/>
   <templateId root="2.16.840.1.113883.3.88.11.32.1" assigningAuthorityName="HITSP/C32"/>
-  <id root="2.16.840.1.113883.3.72" extension="HITSP_C32v2.5_Rev6_16Sections_Entries_MinimalErrors" assigningAuthorityName="NIST Healthcare Project"/>
+  <id root="2.16.840.1.113883.3.72" extension="<%= patient.id %>" assigningAuthorityName="NIST Healthcare Project"/>
   <code code="34133-9" displayName="Summarization of episode note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
   <title>Cypress C32 Patient Test Record: <%= patient.first %> <%= patient.last %></title>
   <effectiveTime value="<%= Time.now.utc.to_formatted_s(:number) %>"/>

--- a/test/fixtures/records/rosa.json
+++ b/test/fixtures/records/rosa.json
@@ -54,6 +54,18 @@
         "value" : { "scalar" : 26,
         "units" : null },
     "time" : 1266664414,
+    "description" : "BMI" },
+    { "codes" : { "SNOMED-CT" : [ 
+        "225171007" ] },
+        "value" : { "scalar" : "true",
+        "units" : null },
+    "time" : 1266664414,
+    "description" : "BMI" },
+	{ "codes" : { "SNOMED-CT" : [ 
+        "225171007" ] },
+        "value" : { "scalar" : "testing",
+        "units" : null },
+    "time" : 1266664414,
     "description" : "BMI" } ],
   "procedures" : [ 
     { "codes" : { "SNOMED-CT" : [ 

--- a/test/unit/export/c32_test.rb
+++ b/test/unit/export/c32_test.rb
@@ -7,9 +7,9 @@ class C32Test < MiniTest::Unit::TestCase
     @pi = HealthDataStandards::Import::C32::PatientImporter.instance
     @record = Record.find('4dcbecdb431a5f5878000004')
     c32 = HealthDataStandards::Export::C32.export(@record)
-    doc = Nokogiri::XML(c32)
-    doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    @patient = @pi.parse_c32(doc)
+    @doc = Nokogiri::XML(c32)
+    @doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+    @patient = @pi.parse_c32(@doc)
   end
   
   def test_demographics
@@ -47,6 +47,15 @@ class C32Test < MiniTest::Unit::TestCase
     assert_equal 1266664414, vital.time
     assert_equal({"SNOMED-CT" => ["225171007"]}, vital.codes)
     assert_equal "26", vital.value[:scalar]
+    vital = @patient.vital_signs[1]
+    assert_equal "true", vital.value[:scalar]
+    vital = @patient.vital_signs[2]
+    assert_equal "testing", vital.value[:scalar]
+    # make sure that the 
+    assert_equal 1,@doc.xpath("//cda:observation[cda:templateId/@root='2.16.840.1.113883.3.88.11.83.14']/cda:value[. = 'testing' and @xsi:type = 'ST']").length
+    assert_equal 1, @doc.xpath("//cda:observation[cda:templateId/@root='2.16.840.1.113883.3.88.11.83.14']/cda:value[@value = '26'  and @xsi:type = 'PQ']").length
+    assert_equal 1, @doc.xpath("//cda:observation[cda:templateId/@root='2.16.840.1.113883.3.88.11.83.14']/cda:value[@value = 'true'  and @xsi:type = 'BL']").length
+
   end
   
   def test_procedures


### PR DESCRIPTION
I updated the import export code to deal with value elements that are not just physical quantities.  Export now looks to see if something is a number before it creates a PQ type.  If it is not a number it checks if the value is either true or false and creates a BL type if it is, otherwise the catch all for leftovers is an ST type.
