### PR TITLE
Add support for negation indicator and reason on other sections

### DIFF
--- a/lib/health-data-standards/import/c32/allergy_importer.rb
+++ b/lib/health-data-standards/import/c32/allergy_importer.rb
@@ -29,6 +29,7 @@ module HealthDataStandards
             extract_codes(entry_element, allergy)
             extract_dates(entry_element, allergy)
             extract_description(entry_element, allergy, id_map)
+            extract_negation(entry_element, allergy)
             
             allergy.status = extract_status(entry_element, allergy)
             allergy.type = extract_code(entry_element, @type_xpath)

--- a/lib/health-data-standards/import/c32/care_goal_importer.rb
+++ b/lib/health-data-standards/import/c32/care_goal_importer.rb
@@ -22,7 +22,8 @@ module HealthDataStandards
                        end
             
             entry = importer.create_entry(goal_element, id_map={})
-            
+            extract_negation(goal_element, entry)
+
             
             
             if @check_for_usable

--- a/lib/health-data-standards/import/c32/condition_importer.rb
+++ b/lib/health-data-standards/import/c32/condition_importer.rb
@@ -28,6 +28,7 @@ module HealthDataStandards
             extract_description(entry_element, condition, id_map)
             extract_cause_of_death(entry_element, condition) if @cod_xpath
             extract_type(entry_element, condition)
+            extract_negation(entry_element, condition)
 
             if @provider_xpath
               entry_element.xpath(@provider_xpath).each do |provider_element|

--- a/lib/health-data-standards/import/c32/encounter_importer.rb
+++ b/lib/health-data-standards/import/c32/encounter_importer.rb
@@ -42,6 +42,7 @@ module HealthDataStandards
           extract_performer(entry_element, encounter)
           extract_facility(entry_element, encounter)
           extract_reason(entry_element, encounter, id_map)
+          extract_negation(entry_element, encounter)
           extract_admission(entry_element, encounter)
           encounter
         end

--- a/lib/health-data-standards/import/c32/immunization_importer.rb
+++ b/lib/health-data-standards/import/c32/immunization_importer.rb
@@ -7,7 +7,6 @@ module HealthDataStandards
           @entry_xpath = "//cda:section[cda:templateId/@root='2.16.840.1.113883.3.88.11.83.117']/cda:entry/cda:substanceAdministration"
           @code_xpath = "./cda:consumable/cda:manufacturedProduct/cda:manufacturedMaterial/cda:code"
           @description_xpath = "./cda:consumable/cda:manufacturedProduct/cda:manufacturedMaterial/cda:code/cda:originalText/cda:reference[@value]"
-          @refusal_reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.1.27']/cda:code"
           @check_for_usable = true               # Pilot tools will set this to false
         end
 
@@ -25,7 +24,7 @@ module HealthDataStandards
             extract_codes(entry_element, immunization)
             extract_dates(entry_element, immunization)
             extract_description(entry_element, immunization, id_map)
-            extract_refusal(entry_element, immunization)
+            extract_negation(entry_element, immunization)
             extract_performer(entry_element, immunization)
             if @check_for_usable
               immunization_list << immunization if immunization.usable?
@@ -37,19 +36,6 @@ module HealthDataStandards
         end
     
         private
-        def extract_refusal(parent_element, immunization)
-          negation_indicator = parent_element['negationInd']
-          unless negation_indicator.nil?
-            immunization.refusal_ind = negation_indicator.eql?('true')
-            if immunization.refusal_ind
-              refusal_reason_element = parent_element.at_xpath(@refusal_reason_xpath)
-              if refusal_reason_element
-                immunization.refusal_reason = {'code' => refusal_reason_element['code'],
-                                               'codeSystem' => 'HL7 No Immunization Reason'}
-              end
-            end
-          end
-        end
     
         def extract_performer(parent_element, immunization)
           performer_element = parent_element.at_xpath("./cda:performer")

--- a/lib/health-data-standards/import/c32/medication_importer.rb
+++ b/lib/health-data-standards/import/c32/medication_importer.rb
@@ -50,6 +50,7 @@ module HealthDataStandards
           extract_order_information(entry_element, medication)
           
           extract_fulfillment_history(entry_element, medication)
+          extract_negation(entry_element, medication)
           
           medication
         end

--- a/lib/health-data-standards/import/c32/procedure_importer.rb
+++ b/lib/health-data-standards/import/c32/procedure_importer.rb
@@ -41,6 +41,7 @@ module HealthDataStandards
           extract_description(entry_element, procedure, id_map)
           extract_performer(entry_element, procedure)
           extract_site(entry_element, procedure)
+          extract_negation(entry_element, procedure)
           procedure
         end
 

--- a/lib/health-data-standards/import/c32/result_importer.rb
+++ b/lib/health-data-standards/import/c32/result_importer.rb
@@ -36,6 +36,7 @@ module HealthDataStandards
           extract_value(entry_element, result)
           extract_description(entry_element, result, id_map)
           extract_interpretation(entry_element, result)
+          extract_negation(entry_element, result)
           result
         end
     

--- a/lib/health-data-standards/import/c32/section_importer.rb
+++ b/lib/health-data-standards/import/c32/section_importer.rb
@@ -195,6 +195,22 @@ module HealthDataStandards
           tele
         end
 
+        def extract_negation(parent_element, entry)
+          negation_indicator = parent_element['negationInd']
+          unless negation_indicator.nil?
+            entry.negation_ind = negation_indicator.eql?('true')
+            if entry.negation_ind
+              negation_reason_element = parent_element.at_xpath("./cda:entryRelationship[@typeCode='RSON']/cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.1.27']/cda:code")
+              if negation_reason_element
+                code_system_oid = negation_reason_element['codeSystem']
+                code = negation_reason_element['code']
+                code_system = HealthDataStandards::Util::CodeSystemHelper.code_system_for(code_system_oid)
+                entry.negation_reason = {'code' => code, 'codeSystem' => code_system}
+              end
+            end
+          end
+        end
+    
         def extract_code(parent_element, code_xpath, code_system=nil)
           code_element = parent_element.at_xpath(code_xpath)
           code_hash = nil

--- a/lib/health-data-standards/import/green_c32/immunization_importer.rb
+++ b/lib/health-data-standards/import/green_c32/immunization_importer.rb
@@ -13,7 +13,7 @@ module HealthDataStandards
           extract_code(immunization_element, immunization, "./gc32:refusalReason")
           series_number = extract_node_text(immunization_element.at_xpath("./gc32:seriesNumber"))
           immunization.series_number = series_number.to_i if series_number
-          immunization.refusalInd = extract_node_attribute(immunization_element, :refused, true)
+          immunization.refusal_ind = extract_node_attribute(immunization_element, :refused, true)
           immunization
         end
         

--- a/lib/health-data-standards/import/green_c32/section_importer.rb
+++ b/lib/health-data-standards/import/green_c32/section_importer.rb
@@ -142,8 +142,7 @@ module HealthDataStandards
         def extract_free_text(element, entry, free_text_element="freeText")
           entry.free_text = extract_node_text(element.at_xpath("./gc32:#{free_text_element}"))
         end
-        
-        
+                
         private
         
         def build_code(code_element)

--- a/lib/health-data-standards/models/entry.rb
+++ b/lib/health-data-standards/models/entry.rb
@@ -16,6 +16,13 @@ class Entry
   field :value, type: Hash, default: {}
   field :free_text, type: String
   field :mood_code, type: String, default: "EVN"
+  field :negationInd, type: Boolean
+  field :negationReason, type: Hash
+  
+  alias :negation_ind :negationInd
+  alias :negation_ind= :negationInd=
+  alias :negation_reason :negationReason
+  alias :negation_reason= :negationReason=
   
   attr_protected :version
   attr_protected :_id

--- a/lib/health-data-standards/models/immunization.rb
+++ b/lib/health-data-standards/models/immunization.rb
@@ -1,16 +1,14 @@
 class Immunization < Entry
-  field :refusalInd, type: Boolean
-  field :refusalReason, type: Hash
   field :seriesNumber, type: Integer
   
   belongs_to :performer, class_name: "Provider"
   
   embeds_one :medication_product
   
-  alias :refusal_ind :refusalInd
-  alias :refusal_ind= :refusalInd=
-  alias :refusal_reason :refusalReason
-  alias :refusal_reason= :refusalReason=
+  alias :refusal_ind :negationInd
+  alias :refusal_ind= :negationInd=
+  alias :refusal_reason :negationReason
+  alias :refusal_reason= :negationReason=
   alias :series_number :seriesNumber
   alias :series_number= :seriesNumber=
 end

--- a/test/fixtures/NISTExampleC32.xml
+++ b/test/fixtures/NISTExampleC32.xml
@@ -964,6 +964,92 @@
               </entryRelationship>
             </procedure>
           </entry>
+          <entry typeCode="DRIV">
+            <procedure classCode="PROC" moodCode="EVN" negationInd="true">
+              <templateId root="2.16.840.1.113883.3.88.11.83.17" assigningAuthorityName="HITSP C83"/>
+              <templateId root="2.16.840.1.113883.10.20.1.29" assigningAuthorityName="CCD"/>
+              <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.19" assigningAuthorityName="IHE PCC"/>
+              <!-- Procedure activity template -->
+              <id root="e401f340-7be2-11db-9fe1-0800200c9a66"/>
+              <code code="52734007" codeSystem="2.16.840.1.113883.6.96" displayName="Total hip replacement">
+                <originalText>Total hip replacement, left<reference value="#Proc1"/> not done - patient objection
+                </originalText>
+                <qualifier>
+                  <name code="272741003" displayName="Laterality"/>
+                  <value code="7771000" displayName="Left"/>
+                </qualifier>
+              </code>
+              <text>IHE Requires reference to go here instead of originalText of code.<reference/>
+              </text>
+              <statusCode code="completed"/>
+              <effectiveTime value="1994"/>
+              <!-- BEGIN MJH Addition -->
+              <targetSiteCode code="1234567" codeSystem="2.16.840.1.113883.6.96" displayName="Dummy"/>
+              <!-- END MJH Addition -->
+              <performer>
+                <assignedEntity>
+                  <id/>
+                  <addr/>
+                  <telecom/>
+            			<assignedPerson>
+            				<name>
+            				  <prefix>Dr.</prefix>
+            					<given>John</given>
+            					<family>Watson</family>
+            					<suffix>MD</suffix>
+            				</name>
+            			</assignedPerson>
+                </assignedEntity>
+              </performer>
+              <participant typeCode="DEV">
+                <participantRole classCode="MANU">
+                  <templateId root="2.16.840.1.113883.10.20.1.52"/>
+                  <!-- Product instance template -->
+                  <id root="03ca01b0-7be1-11db-9fe1-0800200c9a66"/>
+                  <addr/>
+                  <telecom/>
+                  <playingDevice>
+                    <code code="304120007" codeSystem="2.16.840.1.113883.6.96" displayName="Total hip replacement prosthesis"/>
+                  </playingDevice>
+                  <scopingEntity>
+                    <id root="0abea950-5b40-4b7e-b8d9-2a5ea3ac5500"/>
+                    <desc>Good Health Prostheses Company</desc>
+                  </scopingEntity>
+                </participantRole>
+              </participant>
+              <entryRelationship typeCode="REFR">
+                <act classCode="ACT" moodCode="EVN">
+                  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.4" assigningAuthorityName="IHE PCC"/>
+                  <id/>
+                  <code nullFlavor="NA"/>
+                  <text>
+                    <reference value="PtrToSectionText"/>
+                  </text>
+                  <reference typeCode="REFR">
+                    <externalDocument classCode="DOC" moodCode="EVN">
+                      <id/>
+                      <text>Location of Documentation -  URL or other</text>
+                    </externalDocument>
+                  </reference>
+                </act>
+              </entryRelationship>
+              <entryRelationship typeCode="RSON">
+                <act classCode="ACT" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.1.27" assigningAuthorityName="CCD"/>
+                  <id/>
+                  <code nullFlavor="NA" displayName="Patient Objection" code="PATOBJ" codeSystemName="HL7 ActNoImmunizationReason" codeSystem="2.16.840.1.113883.11.19725"/>
+                  <entryRelationship typeCode="SUBJ">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.1.28" assigningAuthorityName="CCD"/>
+                      <code code="PATOBJ" displayName="patient objection" codeSystem="2.16.840.1.113883.11.19725" codeSystemName="HL7 ActNoImmunizationReason"/>
+                      <statusCode code="completed"/>
+                      <effectiveTime nullFlavor="UNK"/>
+                    </observation>
+                  </entryRelationship>
+                </act>
+              </entryRelationship>
+            </procedure>
+          </entry>
         </section>
       </component>
       <component>

--- a/test/unit/import/c32/immunization_importer_test.rb
+++ b/test/unit/import/c32/immunization_importer_test.rb
@@ -17,6 +17,8 @@ class ImmunizationImporterTest < MiniTest::Unit::TestCase
     immunization = patient.immunizations[3]
     assert_equal true, immunization.refusal_ind
     assert_equal 'PATOBJ', immunization.refusal_reason['code']
+    assert_equal true, immunization.negation_ind
+    assert_equal 'PATOBJ', immunization.negation_reason['code']
 
     assert_equal immunization.performer.given_name, 'FirstName'
     assert_equal '100 Bureau Drive', immunization.performer.addresses.first.street.first

--- a/test/unit/import/c32/procedure_importer_test.rb
+++ b/test/unit/import/c32/procedure_importer_test.rb
@@ -8,9 +8,18 @@ class ProcedureImporterTest < MiniTest::Unit::TestCase
     patient = pi.parse_c32(doc)
 
     procedure = patient.procedures[0]
+    assert !procedure.negation_ind
     assert procedure.codes['SNOMED-CT'].include? '52734007'
     assert_equal procedure.performer.title, "Dr."
     assert_equal procedure.performer.family_name, 'Kildare'
+    assert_equal procedure.site['code'], "1234567"
+    assert_equal procedure.site['codeSystem'], "SNOMED-CT"
+    procedure = patient.procedures[1]
+    assert procedure.negation_ind
+    assert_equal 'PATOBJ', procedure.negation_reason['code']
+    assert procedure.codes['SNOMED-CT'].include? '52734007'
+    assert_equal procedure.performer.title, "Dr."
+    assert_equal procedure.performer.family_name, 'Watson'
     assert_equal procedure.site['code'], "1234567"
     assert_equal procedure.site['codeSystem'], "SNOMED-CT"
   end


### PR DESCRIPTION
Currently negations are only supported for immunizations but the latest measures look for negated procedures, medications etc. Maintains immunization specific refusal_ind and refusal_reason but backs those with common negation_ind and negation_reason in entry.
