### PR TITLE
QRDA Importer Refactoring

### DIFF
--- a/lib/health-data-standards.rb
+++ b/lib/health-data-standards.rb
@@ -143,6 +143,7 @@ require_relative 'health-data-standards/import/cat1/lab_order_importer'
 require_relative 'health-data-standards/import/cat1/medication_dispensed_importer'
 require_relative 'health-data-standards/import/cat1/encounter_order_importer'
 require_relative 'health-data-standards/import/cat1/diagnostic_study_order_importer'
+require_relative 'health-data-standards/import/cat1/entry_package'
 
 
 module HealthDataStandards

--- a/lib/health-data-standards/import/cat1/diagnosis_active_importer.rb
+++ b/lib/health-data-standards/import/cat1/diagnosis_active_importer.rb
@@ -11,7 +11,6 @@ module HealthDataStandards
 
         def create_entry(entry_element, nrh = CDA::NarrativeReferenceHandler.new)
           condition = super
-          condition.status = {'SNOMED-CT' => '55561003'}
           condition
         end
       end

--- a/lib/health-data-standards/import/cat1/diagnosis_inactive_importer.rb
+++ b/lib/health-data-standards/import/cat1/diagnosis_inactive_importer.rb
@@ -11,7 +11,6 @@ module HealthDataStandards
 
         def create_entry(entry_element, nrh = CDA::NarrativeReferenceHandler.new)
           condition = super
-          condition.status = {'SNOMED-CT' => '73425007'}
           condition
         end
       end

--- a/lib/health-data-standards/import/cat1/entry_package.rb
+++ b/lib/health-data-standards/import/cat1/entry_package.rb
@@ -3,21 +3,22 @@ module HealthDataStandards
     module Cat1
       class EntryPackage
 
-        attr_accessor :importer_type, :hqmf_oid, :status, :entry
+        attr_accessor :importer_type, :hqmf_oid, :status
 
-        def initialize (doc, type = nil, oid = nil, stat = nil)
+        def initialize (type = nil, oid = nil, stat = nil)
           self.importer_type = type
           self.hqmf_oid = oid
           self.status = stat
-          nrh = CDA::NarrativeReferenceHandler.new
-          nrh.build_id_map(doc)
-          entries = self.importer_type.create_entries(doc, nrh)
-          if !entries.empty?
-            entries[0].oid = self.hqmf_oid
-            entries[0].status = self.status
-            self.entry = entries[0]
-          end
         end  
+
+        def package_entries (doc, nrh)
+          entries = self.importer_type.create_entries(doc, nrh)
+          if entries.present?
+            entries.map {|entry| entry.oid = self.hqmf_oid}
+            entries.map {|entry| entry.status = self.status}
+            entries
+          end
+        end
         
       end
     end

--- a/lib/health-data-standards/import/cat1/entry_package.rb
+++ b/lib/health-data-standards/import/cat1/entry_package.rb
@@ -1,0 +1,25 @@
+module HealthDataStandards
+  module Import
+    module Cat1
+      class EntryPackage
+
+        attr_accessor :importer_type, :hqmf_oid, :status, :entry
+
+        def initialize (doc, type = nil, oid = nil, stat = nil)
+          self.importer_type = type
+          self.hqmf_oid = oid
+          self.status = stat
+          nrh = CDA::NarrativeReferenceHandler.new
+          nrh.build_id_map(doc)
+          entries = self.importer_type.create_entries(doc, nrh)
+          if !entries.empty?
+            entries[0].oid = self.hqmf_oid
+            entries[0].status = self.status
+            self.entry = entries[0]
+          end
+        end  
+        
+      end
+    end
+  end
+end

--- a/lib/health-data-standards/import/cat1/patient_importer.rb
+++ b/lib/health-data-standards/import/cat1/patient_importer.rb
@@ -10,61 +10,61 @@ module HealthDataStandards
       class PatientImporter
         include Singleton
 
-        def import(doc)
+        def initialize
           # This differs from other HDS patient importers in that sections can have multiple importers
           @section_importers = {}
-          @section_importers[:care_goals] = [EntryPackage.new(doc, CDA::SectionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.1']")), '2.16.840.1.113883.3.560.1.9').entry].compact #care goal
+          @section_importers[:care_goals] = [EntryPackage.new(CDA::SectionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.1']")), '2.16.840.1.113883.3.560.1.9')].compact #care goal
 
           ecog_status_importer = CDA::SectionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.103']"))
           ecog_status_importer.code_xpath = './cda:value'
           symptom_active_importer = CDA::SectionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.76']"))
           symptom_active_importer.code_xpath = './cda:value'
           
-          @section_importers[:conditions] = [EntryPackage.new(doc, GestationalAgeImporter.new, '2.16.840.1.113883.3.560.1.1001').entry,
-                                             EntryPackage.new(doc, ecog_status_importer, '2.16.840.1.113883.3.560.1.1001').entry,
-                                             EntryPackage.new(doc, symptom_active_importer, '2.16.840.1.113883.3.560.1.69', 'active').entry,
-                                             EntryPackage.new(doc, DiagnosisActiveImporter.new, '2.16.840.1.113883.3.560.1.2', 'active').entry,
-                                             EntryPackage.new(doc, CDA::ConditionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.54']")), '2.16.840.1.113883.3.560.1.404').entry, # patient characteristic age
-                                             EntryPackage.new(doc, CDA::ConditionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.14']")), '2.16.840.1.113883.3.560.1.24', 'resolved').entry, #diagnosis resolved
-                                             EntryPackage.new(doc, DiagnosisInactiveImporter.new, '2.16.840.1.113883.3.560.1.23', 'inactive').entry].compact #diagnosis inactive
+          @section_importers[:conditions] = [EntryPackage.new(GestationalAgeImporter.new, '2.16.840.1.113883.3.560.1.1001'),
+                                             EntryPackage.new(ecog_status_importer, '2.16.840.1.113883.3.560.1.1001'),
+                                             EntryPackage.new(symptom_active_importer, '2.16.840.1.113883.3.560.1.69', 'active'),
+                                             EntryPackage.new(DiagnosisActiveImporter.new, '2.16.840.1.113883.3.560.1.2', 'active'),
+                                             EntryPackage.new(CDA::ConditionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.54']")), '2.16.840.1.113883.3.560.1.404'), # patient characteristic age
+                                             EntryPackage.new(CDA::ConditionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.14']")), '2.16.840.1.113883.3.560.1.24', 'resolved'), #diagnosis resolved
+                                             EntryPackage.new(DiagnosisInactiveImporter.new, '2.16.840.1.113883.3.560.1.23', 'inactive')].compact #diagnosis inactive
   
           
-          @section_importers[:medications] = [EntryPackage.new(doc, CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.105']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.41']")), '2.16.840.1.113883.3.560.1.199', 'discharge').entry, #discharge medication active
-                                              EntryPackage.new(doc, CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.41']")), '2.16.840.1.113883.3.560.1.13', 'active').entry, #medication active
-                                              EntryPackage.new(doc, CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.42']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.22.4.16']")), '2.16.840.1.113883.3.560.1.14', 'administered').entry, #medication administered
-                                              EntryPackage.new(doc, CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.47']")), '2.16.840.1.113883.3.560.1.17', 'ordered').entry, #medication order TODO: ADD NEGATON REASON HANDLING SOMEHOW
-                                              EntryPackage.new(doc, MedicationDispensedImporter.new, '2.16.840.1.113883.3.560.1.8', 'dispensed').entry].compact
+          @section_importers[:medications] = [EntryPackage.new(CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.105']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.41']")), '2.16.840.1.113883.3.560.1.199', 'discharge'), #discharge medication active
+                                              EntryPackage.new(CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.41']")), '2.16.840.1.113883.3.560.1.13', 'active'), #medication active
+                                              EntryPackage.new(CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.42']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.22.4.16']")), '2.16.840.1.113883.3.560.1.14', 'administered'), #medication administered
+                                              EntryPackage.new(CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.47']")), '2.16.840.1.113883.3.560.1.17', 'ordered'), #medication order TODO: ADD NEGATON REASON HANDLING SOMEHOW
+                                              EntryPackage.new(MedicationDispensedImporter.new, '2.16.840.1.113883.3.560.1.8', 'dispensed')].compact
 
-          @section_importers[:procedures] = [EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.59']")), '2.16.840.1.113883.3.560.1.57', 'performed').entry, #physical exam performed
-                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.3']")), '2.16.840.1.113883.3.560.1.131').entry, #comm from provider to patient
-                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.31']")), '2.16.840.1.113883.3.560.1.45', 'ordered').entry, #intervention ordered
-                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.32']")), '2.16.840.1.113883.3.560.1.46', 'performed').entry, #intervention performed
-                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']")), '2.16.840.1.113883.3.560.1.47').entry, #intervention result
-                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.4']")), '2.16.840.1.113883.3.560.1.129').entry, #comm from provider to provider
-                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.2']")), '2.16.840.1.113883.3.560.1.30').entry, #comm from patient to provider
-                                             EntryPackage.new(doc, ProcedureOrderImporter.new, '2.16.840.1.113883.3.560.1.62', 'ordered').entry,
-                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.64']")), '2.16.840.1.113883.3.560.1.6').entry,
-                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.66']")), '2.16.840.1.113883.3.560.1.63').entry,
-                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.69']")), '2.16.840.1.113883.3.560.1.21').entry,
-                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.18']")), '2.16.840.1.113883.3.560.1.103', 'performed').entry, #diagnostic study performed
-                                             EntryPackage.new(doc, DiagnosticStudyOrderImporter.new, '2.16.840.1.113883.3.560.1.40', 'ordered').entry].compact
+          @section_importers[:procedures] = [EntryPackage.new(CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.59']")), '2.16.840.1.113883.3.560.1.57', 'performed'), #physical exam performed
+                                             EntryPackage.new(CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.3']")), '2.16.840.1.113883.3.560.1.131'), #comm from provider to patient
+                                             EntryPackage.new(CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.31']")), '2.16.840.1.113883.3.560.1.45', 'ordered'), #intervention ordered
+                                             EntryPackage.new(CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.32']")), '2.16.840.1.113883.3.560.1.46', 'performed'), #intervention performed
+                                             EntryPackage.new(CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']")), '2.16.840.1.113883.3.560.1.47'), #intervention result
+                                             EntryPackage.new(CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.4']")), '2.16.840.1.113883.3.560.1.129'), #comm from provider to provider
+                                             EntryPackage.new(CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.2']")), '2.16.840.1.113883.3.560.1.30'), #comm from patient to provider
+                                             EntryPackage.new(ProcedureOrderImporter.new, '2.16.840.1.113883.3.560.1.62', 'ordered'),
+                                             EntryPackage.new(CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.64']")), '2.16.840.1.113883.3.560.1.6'),
+                                             EntryPackage.new(CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.66']")), '2.16.840.1.113883.3.560.1.63'),
+                                             EntryPackage.new(CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.69']")), '2.16.840.1.113883.3.560.1.21'),
+                                             EntryPackage.new(CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.18']")), '2.16.840.1.113883.3.560.1.103', 'performed'), #diagnostic study performed
+                                             EntryPackage.new(DiagnosticStudyOrderImporter.new, '2.16.840.1.113883.3.560.1.40', 'ordered')].compact
 
-          @section_importers[:allergies] = [EntryPackage.new(doc, ProcedureIntoleranceImporter.new, '2.16.840.1.113883.3.560.1.61').entry,
-                                            EntryPackage.new(doc, CDA::AllergyImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.46']")), '2.16.840.1.113883.3.560.1.67').entry, #medication intolerance
-                                            EntryPackage.new(doc, CDA::AllergyImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.43']")), '2.16.840.1.113883.3.560.1.7').entry, #medication adverse effect
-                                            EntryPackage.new(doc, CDA::AllergyImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.44']")), '2.16.840.1.113883.3.560.1.1').entry].compact #medication allergy
+          @section_importers[:allergies] = [EntryPackage.new(ProcedureIntoleranceImporter.new, '2.16.840.1.113883.3.560.1.61'),
+                                            EntryPackage.new(CDA::AllergyImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.46']")), '2.16.840.1.113883.3.560.1.67'), #medication intolerance
+                                            EntryPackage.new(CDA::AllergyImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.43']")), '2.16.840.1.113883.3.560.1.7'), #medication adverse effect
+                                            EntryPackage.new(CDA::AllergyImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.44']")), '2.16.840.1.113883.3.560.1.1')].compact #medication allergy
 
-          @section_importers[:medical_equipment] = [EntryPackage.new(doc, CDA::MedicalEquipmentImporter.new(CDA::EntryFinder.new("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.7']")), '2.16.840.1.113883.3.560.1.110', 'applied').entry].compact
+          @section_importers[:medical_equipment] = [EntryPackage.new(CDA::MedicalEquipmentImporter.new(CDA::EntryFinder.new("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.7']")), '2.16.840.1.113883.3.560.1.110', 'applied')].compact
 
-          @section_importers[:results] = [EntryPackage.new(doc, LabOrderImporter.new, '2.16.840.1.113883.3.560.1.50', 'ordered').entry, #lab ordered
-                                          EntryPackage.new(doc, CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.38']")), '2.16.840.1.113883.3.560.1.5', 'performed').entry, #lab performed
-                                          EntryPackage.new(doc, CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']")), '2.16.840.1.113883.3.560.1.47').entry, #intervention result
-                                          EntryPackage.new(doc, CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.57']")), '2.16.840.1.113883.3.560.1.18').entry, #physical exam finding
-                                          EntryPackage.new(doc, CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.28']")), '2.16.840.1.113883.3.560.1.88').entry, #functional status result    
-                                          EntryPackage.new(doc, CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.20']")), '2.16.840.1.113883.3.560.1.111').entry].compact #diagnostic study result not done
+          @section_importers[:results] = [EntryPackage.new(LabOrderImporter.new, '2.16.840.1.113883.3.560.1.50', 'ordered'), #lab ordered
+                                          EntryPackage.new(CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.38']")), '2.16.840.1.113883.3.560.1.5', 'performed'), #lab performed
+                                          EntryPackage.new(CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']")), '2.16.840.1.113883.3.560.1.47'), #intervention result
+                                          EntryPackage.new(CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.57']")), '2.16.840.1.113883.3.560.1.18'), #physical exam finding
+                                          EntryPackage.new(CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.28']")), '2.16.840.1.113883.3.560.1.88'), #functional status result    
+                                          EntryPackage.new(CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.20']")), '2.16.840.1.113883.3.560.1.111')].compact #diagnostic study result not done
 
-          @section_importers[:encounters] = [EntryPackage.new(doc, CDA::EncounterImporter.new(CDA::EntryFinder.new("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']")), '2.16.840.1.113883.3.560.1.79', 'performed').entry, #encounter performed
-                                             EntryPackage.new(doc, EncounterOrderImporter.new, '2.16.840.1.113883.3.560.1.83', 'ordered').entry].compact
+          @section_importers[:encounters] = [EntryPackage.new(CDA::EncounterImporter.new(CDA::EntryFinder.new("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']")), '2.16.840.1.113883.3.560.1.79', 'performed'), #encounter performed
+                                             EntryPackage.new(EncounterOrderImporter.new, '2.16.840.1.113883.3.560.1.83', 'ordered')].compact
 
         end 
 
@@ -77,9 +77,12 @@ module HealthDataStandards
         end
 
         def import_sections(record, doc)
-          self.import(doc)
+          nrh = CDA::NarrativeReferenceHandler.new
+          nrh.build_id_map(doc)
           @section_importers.each do |section, entries|
-            record.send(section) << entries
+            entries.each do |entry|
+              record.send(section) << entry.package_entries(doc, nrh)
+            end
           end
         end
 

--- a/lib/health-data-standards/import/cat1/patient_importer.rb
+++ b/lib/health-data-standards/import/cat1/patient_importer.rb
@@ -10,68 +10,61 @@ module HealthDataStandards
       class PatientImporter
         include Singleton
 
-        def initialize
+        def import(doc)
           # This differs from other HDS patient importers in that sections can have multiple importers
           @section_importers = {}
-          @section_importers[:care_goals] = []
-          @section_importers[:care_goals] << CDA::SectionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.1']"))
+          @section_importers[:care_goals] = [EntryPackage.new(doc, CDA::SectionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.1']")), '2.16.840.1.113883.3.560.1.9').entry].compact #care goal
 
-          @section_importers[:conditions] = []
-          @section_importers[:conditions] << GestationalAgeImporter.new
           ecog_status_importer = CDA::SectionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.103']"))
           ecog_status_importer.code_xpath = './cda:value'
-          @section_importers[:conditions] << ecog_status_importer
           symptom_active_importer = CDA::SectionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.76']"))
           symptom_active_importer.code_xpath = './cda:value'
-          @section_importers[:conditions] << symptom_active_importer
-          @section_importers[:conditions] << DiagnosisActiveImporter.new
-          @section_importers[:conditions] << CDA::ConditionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.54']"))
-          @section_importers[:conditions] << CDA::ConditionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.14']")) #diagnosis resolved
-          @section_importers[:conditions] << DiagnosisInactiveImporter.new #diagnosis inactive
+          
+          @section_importers[:conditions] = [EntryPackage.new(doc, GestationalAgeImporter.new, '2.16.840.1.113883.3.560.1.1001').entry,
+                                             EntryPackage.new(doc, ecog_status_importer, '2.16.840.1.113883.3.560.1.1001').entry,
+                                             EntryPackage.new(doc, symptom_active_importer, '2.16.840.1.113883.3.560.1.69', 'active').entry,
+                                             EntryPackage.new(doc, DiagnosisActiveImporter.new, '2.16.840.1.113883.3.560.1.2', 'active').entry,
+                                             EntryPackage.new(doc, CDA::ConditionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.54']")), '2.16.840.1.113883.3.560.1.404').entry, # patient characteristic age
+                                             EntryPackage.new(doc, CDA::ConditionImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.14']")), '2.16.840.1.113883.3.560.1.24', 'resolved').entry, #diagnosis resolved
+                                             EntryPackage.new(doc, DiagnosisInactiveImporter.new, '2.16.840.1.113883.3.560.1.23', 'inactive').entry].compact #diagnosis inactive
   
-          @section_importers[:medications] = []
-          @section_importers[:medications] << CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.105']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.41']"))
-          @section_importers[:medications] << CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.41']")) #medication active
-          @section_importers[:medications] << CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.42']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.22.4.16']")) #medication administered
-          @section_importers[:medications] << CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.47']")) #medication order TODO: ADD NEGATON REASON HANDLING SOMEHOW
-          @section_importers[:medications] << MedicationDispensedImporter.new
+          
+          @section_importers[:medications] = [EntryPackage.new(doc, CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.105']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.41']")), '2.16.840.1.113883.3.560.1.199', 'discharge').entry, #discharge medication active
+                                              EntryPackage.new(doc, CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.41']")), '2.16.840.1.113883.3.560.1.13', 'active').entry, #medication active
+                                              EntryPackage.new(doc, CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.42']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.22.4.16']")), '2.16.840.1.113883.3.560.1.14', 'administered').entry, #medication administered
+                                              EntryPackage.new(doc, CDA::MedicationImporter.new(CDA::EntryFinder.new("//cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.47']")), '2.16.840.1.113883.3.560.1.17', 'ordered').entry, #medication order TODO: ADD NEGATON REASON HANDLING SOMEHOW
+                                              EntryPackage.new(doc, MedicationDispensedImporter.new, '2.16.840.1.113883.3.560.1.8', 'dispensed').entry].compact
 
-          @section_importers[:procedures] = []
-          @section_importers[:procedures] << CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.59']"))
-          @section_importers[:procedures] << CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.3']")) #comm from provider to patient
-          @section_importers[:procedures] << CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.31']")) #intervention ordered
-          @section_importers[:procedures] << CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.32']")) #intervention performed
-          @section_importers[:procedures] << CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']")) #intervention result
-          @section_importers[:procedures] << CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.4']")) #comm from provider to provider
-          @section_importers[:procedures] << CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.2']")) #comm from patient to provider
-          @section_importers[:procedures] << ProcedureOrderImporter.new
-          @section_importers[:procedures] << CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.64']"))
-          @section_importers[:procedures] << CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.66']"))
-          @section_importers[:procedures] << CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.69']"))
-          @section_importers[:procedures] << CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.18']")) #diagnostic study performed
-          @section_importers[:procedures] << DiagnosticStudyOrderImporter.new
+          @section_importers[:procedures] = [EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.59']")), '2.16.840.1.113883.3.560.1.57', 'performed').entry, #physical exam performed
+                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.3']")), '2.16.840.1.113883.3.560.1.131').entry, #comm from provider to patient
+                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.31']")), '2.16.840.1.113883.3.560.1.45', 'ordered').entry, #intervention ordered
+                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.32']")), '2.16.840.1.113883.3.560.1.46', 'performed').entry, #intervention performed
+                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']")), '2.16.840.1.113883.3.560.1.47').entry, #intervention result
+                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.4']")), '2.16.840.1.113883.3.560.1.129').entry, #comm from provider to provider
+                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.2']")), '2.16.840.1.113883.3.560.1.30').entry, #comm from patient to provider
+                                             EntryPackage.new(doc, ProcedureOrderImporter.new, '2.16.840.1.113883.3.560.1.62', 'ordered').entry,
+                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.64']")), '2.16.840.1.113883.3.560.1.6').entry,
+                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.66']")), '2.16.840.1.113883.3.560.1.63').entry,
+                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.69']")), '2.16.840.1.113883.3.560.1.21').entry,
+                                             EntryPackage.new(doc, CDA::ProcedureImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.18']")), '2.16.840.1.113883.3.560.1.103', 'performed').entry, #diagnostic study performed
+                                             EntryPackage.new(doc, DiagnosticStudyOrderImporter.new, '2.16.840.1.113883.3.560.1.40', 'ordered').entry].compact
 
-          @section_importers[:allergies] = []
-          @section_importers[:allergies] << ProcedureIntoleranceImporter.new
-          @section_importers[:allergies] << CDA::AllergyImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.46']")) #medication intolerance
-          @section_importers[:allergies] << CDA::AllergyImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.43']")) #medication adverse effect
-          @section_importers[:allergies] << CDA::AllergyImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.44']")) #medication allergy
+          @section_importers[:allergies] = [EntryPackage.new(doc, ProcedureIntoleranceImporter.new, '2.16.840.1.113883.3.560.1.61').entry,
+                                            EntryPackage.new(doc, CDA::AllergyImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.46']")), '2.16.840.1.113883.3.560.1.67').entry, #medication intolerance
+                                            EntryPackage.new(doc, CDA::AllergyImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.43']")), '2.16.840.1.113883.3.560.1.7').entry, #medication adverse effect
+                                            EntryPackage.new(doc, CDA::AllergyImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.44']")), '2.16.840.1.113883.3.560.1.1').entry].compact #medication allergy
 
-          @section_importers[:medical_equipment] = []
-          @section_importers[:medical_equipment] << CDA::MedicalEquipmentImporter.new(CDA::EntryFinder.new("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.7']"))
+          @section_importers[:medical_equipment] = [EntryPackage.new(doc, CDA::MedicalEquipmentImporter.new(CDA::EntryFinder.new("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.7']")), '2.16.840.1.113883.3.560.1.110', 'applied').entry].compact
 
-          @section_importers[:results] = []
-          @section_importers[:results] << LabOrderImporter.new #lab ordered
-          @section_importers[:results] << CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.38']")) #lab performed
-          @section_importers[:results] << CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']")) #intervention result
-          @section_importers[:results] << CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.57']")) #physical exam finding
-          @section_importers[:results] << CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.28']")) #functional status result    
-          @section_importers[:results] << CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.20']")) #diagnostic study result
+          @section_importers[:results] = [EntryPackage.new(doc, LabOrderImporter.new, '2.16.840.1.113883.3.560.1.50', 'ordered').entry, #lab ordered
+                                          EntryPackage.new(doc, CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.38']")), '2.16.840.1.113883.3.560.1.5', 'performed').entry, #lab performed
+                                          EntryPackage.new(doc, CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']")), '2.16.840.1.113883.3.560.1.47').entry, #intervention result
+                                          EntryPackage.new(doc, CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.57']")), '2.16.840.1.113883.3.560.1.18').entry, #physical exam finding
+                                          EntryPackage.new(doc, CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.28']")), '2.16.840.1.113883.3.560.1.88').entry, #functional status result    
+                                          EntryPackage.new(doc, CDA::ResultImporter.new(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.20']")), '2.16.840.1.113883.3.560.1.111').entry].compact #diagnostic study result not done
 
-          @section_importers[:encounters] = []
-          @section_importers[:encounters] << CDA::EncounterImporter.new(CDA::EntryFinder.new("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']")) #encounter performed
-          @section_importers[:encounters] << EncounterOrderImporter.new
-
+          @section_importers[:encounters] = [EntryPackage.new(doc, CDA::EncounterImporter.new(CDA::EntryFinder.new("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']")), '2.16.840.1.113883.3.560.1.79', 'performed').entry, #encounter performed
+                                             EntryPackage.new(doc, EncounterOrderImporter.new, '2.16.840.1.113883.3.560.1.83', 'ordered').entry].compact
 
         end 
 
@@ -84,13 +77,9 @@ module HealthDataStandards
         end
 
         def import_sections(record, doc)
-          nrh = CDA::NarrativeReferenceHandler.new
-          nrh.build_id_map(doc)
-          @section_importers.each_pair do |section, importers|
-            importers.each do |importer|
-              entries = importer.create_entries(doc, nrh)
-              record.send(section) << entries
-            end
+          self.import(doc)
+          @section_importers.each do |section, entries|
+            record.send(section) << entries
           end
         end
 

--- a/test/fixtures/cat1_fragments/care_goal_fragment.xml
+++ b/test/fixtures/cat1_fragments/care_goal_fragment.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="cda.xsl"?>
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:hl7-org:v3" xmlns:voc="urn:hl7-org:v3/voc" xmlns:sdtc="urn:hl7-org:sdtc">
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <entry>
+            <observation classCode="OBS" moodCode="GOL">
+              <!-- 2.16.840.1.113883.10.20.22.4.44 Plan of Care Activity Observation -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.44"/>
+              <templateId root="2.16.840.1.113883.10.20.24.3.1"/>
+              <id root="F3D6FD73-B2C0-4274-BFD2-A485957734DB"/>
+              <code code="252465000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Pulse oximetry" sdtc:valueSet="2.16.840.1.113883.6.103"/>
+              <text>Care Goal: Pulse Oximetry greater than 92%</text>
+              <statusCode code="active"/>
+              <effectiveTime>
+                <low value="201101011400"/> 
+              </effectiveTime>
+            </observation>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test/unit/import/cat1/diagnosis_active_importer_test.rb
+++ b/test/unit/import/cat1/diagnosis_active_importer_test.rb
@@ -4,15 +4,12 @@ class DiagnosisActiveImporterTest < MiniTest::Unit::TestCase
   def test_diagnosis_active_importing
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/diagnosis_active_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    dai = HealthDataStandards::Import::Cat1::DiagnosisActiveImporter.new
-    entries = dai.create_entries(doc)
-    
-    diagnosis = entries[0]
+    diagnosis = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::DiagnosisActiveImporter.new, '2.16.840.1.113883.3.560.1.2', 'active').entry
     assert diagnosis.codes['ICD-9-CM'].include?("999.34")
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19890903081502')
     expected_end = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19890904034509')
     assert_equal expected_start, diagnosis.start_time
     assert_equal expected_end, diagnosis.end_time
-    assert_equal '55561003', diagnosis.status['SNOMED-CT'] # asserting that the condition is active
+    assert_equal 'active', diagnosis.status # asserting that the condition is active
   end
 end

--- a/test/unit/import/cat1/diagnosis_active_importer_test.rb
+++ b/test/unit/import/cat1/diagnosis_active_importer_test.rb
@@ -4,7 +4,11 @@ class DiagnosisActiveImporterTest < MiniTest::Unit::TestCase
   def test_diagnosis_active_importing
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/diagnosis_active_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    diagnosis = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::DiagnosisActiveImporter.new, '2.16.840.1.113883.3.560.1.2', 'active').entry
+    nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
+    nrh.build_id_map(doc)
+    diag = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::DiagnosisActiveImporter.new, '2.16.840.1.113883.3.560.1.2', 'active')
+    diagnoses = diag.package_entries(doc, nrh)
+    diagnosis = diagnoses[0]
     assert diagnosis.codes['ICD-9-CM'].include?("999.34")
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19890903081502')
     expected_end = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19890904034509')

--- a/test/unit/import/cat1/diagnosis_inactive_importer_test.rb
+++ b/test/unit/import/cat1/diagnosis_inactive_importer_test.rb
@@ -4,16 +4,12 @@ class DiagnosisInactiveImporterTest < MiniTest::Unit::TestCase
   def test_diagnosis_active_importing
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/diagnosis_inactive_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    dia = HealthDataStandards::Import::Cat1::DiagnosisInactiveImporter.new
-    entries = dia.create_entries(doc)
-    
-    diagnosis = entries[0]
-    
+    diagnosis = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::DiagnosisInactiveImporter.new, '2.16.840.1.113883.3.560.1.23', 'inactive').entry
     assert diagnosis.codes['ICD-9-CM'].include?("V02.61")
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('20040816121859')
     expected_end = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('20040816200929')
     assert_equal expected_start, diagnosis.start_time
     assert_equal expected_end, diagnosis.end_time
-    assert_equal '73425007', diagnosis.status['SNOMED-CT'] # asserting that the condition is active
+    assert_equal 'inactive', diagnosis.status # asserting that the condition is active
   end
 end

--- a/test/unit/import/cat1/diagnosis_inactive_importer_test.rb
+++ b/test/unit/import/cat1/diagnosis_inactive_importer_test.rb
@@ -4,7 +4,11 @@ class DiagnosisInactiveImporterTest < MiniTest::Unit::TestCase
   def test_diagnosis_active_importing
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/diagnosis_inactive_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    diagnosis = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::DiagnosisInactiveImporter.new, '2.16.840.1.113883.3.560.1.23', 'inactive').entry
+    nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
+    nrh.build_id_map(doc)
+    diag = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::DiagnosisInactiveImporter.new, '2.16.840.1.113883.3.560.1.23', 'inactive')
+    diagnoses = diag.package_entries(doc, nrh)
+    diagnosis = diagnoses[0]
     assert diagnosis.codes['ICD-9-CM'].include?("V02.61")
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('20040816121859')
     expected_end = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('20040816200929')

--- a/test/unit/import/cat1/diagnostic_study_order_test.rb
+++ b/test/unit/import/cat1/diagnostic_study_order_test.rb
@@ -4,7 +4,11 @@ class DiagnosticStudyOrderImporterTest < MiniTest::Unit::TestCase
   def test_encounter_order_importing
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/diagnostic_study_order_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    order = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::DiagnosticStudyOrderImporter.new, '2.16.840.1.113883.3.560.1.40', 'ordered').entry
+    nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
+    nrh.build_id_map(doc)
+    ord = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::DiagnosticStudyOrderImporter.new, '2.16.840.1.113883.3.560.1.40', 'ordered')
+    orders = ord.package_entries(doc, nrh)
+    order = orders[0]
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19891215072420')
     assert order.codes['LOINC'].include?("69399-4")
     assert_equal expected_start, order.start_time

--- a/test/unit/import/cat1/diagnostic_study_order_test.rb
+++ b/test/unit/import/cat1/diagnostic_study_order_test.rb
@@ -4,11 +4,7 @@ class DiagnosticStudyOrderImporterTest < MiniTest::Unit::TestCase
   def test_encounter_order_importing
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/diagnostic_study_order_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    study_order = HealthDataStandards::Import::Cat1::DiagnosticStudyOrderImporter.new
-    entries = study_order.create_entries(doc)
-    
-    order = entries[0]
-    
+    order = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::DiagnosticStudyOrderImporter.new, '2.16.840.1.113883.3.560.1.40', 'ordered').entry
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19891215072420')
     assert order.codes['LOINC'].include?("69399-4")
     assert_equal expected_start, order.start_time

--- a/test/unit/import/cat1/encounter_order_importer_test.rb
+++ b/test/unit/import/cat1/encounter_order_importer_test.rb
@@ -4,11 +4,7 @@ class EncounterOrderImporterTest < MiniTest::Unit::TestCase
   def test_encounter_order_importing
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/encounter_order_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    enc_order = HealthDataStandards::Import::Cat1::EncounterOrderImporter.new
-    entries = enc_order.create_entries(doc)
-    
-    enc = entries[0]
-
+    enc = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::EncounterOrderImporter.new, '2.16.840.1.113883.3.560.1.83', 'ordered').entry
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('20051226144034')
     assert enc.codes['SNOMED-CT'].include?("76168009")
     assert_equal expected_start, enc.start_time

--- a/test/unit/import/cat1/encounter_order_importer_test.rb
+++ b/test/unit/import/cat1/encounter_order_importer_test.rb
@@ -4,9 +4,13 @@ class EncounterOrderImporterTest < MiniTest::Unit::TestCase
   def test_encounter_order_importing
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/encounter_order_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    enc = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::EncounterOrderImporter.new, '2.16.840.1.113883.3.560.1.83', 'ordered').entry
+    nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
+    nrh.build_id_map(doc)
+    enc = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::EncounterOrderImporter.new, '2.16.840.1.113883.3.560.1.83', 'ordered')
+    encounters = enc.package_entries(doc, nrh)
+    encounter = encounters[0]
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('20051226144034')
-    assert enc.codes['SNOMED-CT'].include?("76168009")
-    assert_equal expected_start, enc.start_time
+    assert encounter.codes['SNOMED-CT'].include?("76168009")
+    assert_equal expected_start, encounter.start_time
   end
 end

--- a/test/unit/import/cat1/gestational_age_importer_test.rb
+++ b/test/unit/import/cat1/gestational_age_importer_test.rb
@@ -4,7 +4,11 @@ class GestationalAgeImporterTest < MiniTest::Unit::TestCase
   def test_gestational_age_importing
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/gestational_age_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    gai = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::GestationalAgeImporter.new, '2.16.840.1.113883.3.560.1.1001').entry
-		assert gai.codes['SNOMED-CT'].include?("931004")
+    nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
+    nrh.build_id_map(doc)
+    gai = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::GestationalAgeImporter.new, '2.16.840.1.113883.3.560.1.1001')
+		gais = gai.package_entries(doc, nrh)
+		gestational_age = gais[0]
+		assert gestational_age.codes['SNOMED-CT'].include?("931004")
   end
 end

--- a/test/unit/import/cat1/gestational_age_importer_test.rb
+++ b/test/unit/import/cat1/gestational_age_importer_test.rb
@@ -4,10 +4,7 @@ class GestationalAgeImporterTest < MiniTest::Unit::TestCase
   def test_gestational_age_importing
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/gestational_age_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    gai = HealthDataStandards::Import::Cat1::GestationalAgeImporter.new
-    entries = gai.create_entries(doc)
-    
-    ga = entries[0]
-    assert ga.codes['SNOMED-CT'].include?("931004")
+    gai = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::GestationalAgeImporter.new, '2.16.840.1.113883.3.560.1.1001').entry
+		assert gai.codes['SNOMED-CT'].include?("931004")
   end
 end

--- a/test/unit/import/cat1/lab_order_importer_test.rb
+++ b/test/unit/import/cat1/lab_order_importer_test.rb
@@ -4,7 +4,11 @@ class LabOrderImporterTest < MiniTest::Unit::TestCase
   def test_encounter_order_importing
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/lab_order_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    lab_order = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::LabOrderImporter.new, '2.16.840.1.113883.3.560.1.50', 'ordered').entry
+    nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
+    nrh.build_id_map(doc)
+    lo = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::LabOrderImporter.new, '2.16.840.1.113883.3.560.1.50', 'ordered')
+    lab_orders = lo.package_entries(doc, nrh)
+    lab_order = lab_orders[0]
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19910519162436')
     assert lab_order.codes['SNOMED-CT'].include?('8879006')
     assert_equal expected_start, lab_order.start_time

--- a/test/unit/import/cat1/lab_order_importer_test.rb
+++ b/test/unit/import/cat1/lab_order_importer_test.rb
@@ -4,13 +4,9 @@ class LabOrderImporterTest < MiniTest::Unit::TestCase
   def test_encounter_order_importing
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/lab_order_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    lab_order = HealthDataStandards::Import::Cat1::LabOrderImporter.new
-    entries = lab_order.create_entries(doc)
-    
-    lab = entries[0]
-
+    lab_order = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::LabOrderImporter.new, '2.16.840.1.113883.3.560.1.50', 'ordered').entry
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19910519162436')
-    assert lab.codes['SNOMED-CT'].include?("8879006")
-    assert_equal expected_start, lab.start_time
+    assert lab_order.codes['SNOMED-CT'].include?('8879006')
+    assert_equal expected_start, lab_order.start_time
   end
 end

--- a/test/unit/import/cat1/medication_dispensed_test.rb
+++ b/test/unit/import/cat1/medication_dispensed_test.rb
@@ -4,11 +4,7 @@ class MedicationDispensedImporterTest < MiniTest::Unit::TestCase
   def test_medication_dispensed_importing
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/medication_dispensed_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    med_disp = HealthDataStandards::Import::Cat1::MedicationDispensedImporter.new
-    entries = med_disp.create_entries(doc)
-
-    med = entries[0]
-    
+    med = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::MedicationDispensedImporter.new, '2.16.840.1.113883.3.560.1.8', 'dispensed').entry
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19960119172123')
     expected_end = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19960119221325')
     assert med.codes['RxNorm'].include?("977869")

--- a/test/unit/import/cat1/medication_dispensed_test.rb
+++ b/test/unit/import/cat1/medication_dispensed_test.rb
@@ -4,11 +4,15 @@ class MedicationDispensedImporterTest < MiniTest::Unit::TestCase
   def test_medication_dispensed_importing
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/medication_dispensed_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    med = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::MedicationDispensedImporter.new, '2.16.840.1.113883.3.560.1.8', 'dispensed').entry
+    nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
+    nrh.build_id_map(doc)
+    med = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::MedicationDispensedImporter.new, '2.16.840.1.113883.3.560.1.8', 'dispensed')
+    medications = med.package_entries(doc, nrh)
+    medication = medications[0]
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19960119172123')
     expected_end = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19960119221325')
-    assert med.codes['RxNorm'].include?("977869")
-    assert_equal expected_start, med.start_time
-    assert_equal expected_end, med.end_time
+    assert medication.codes['RxNorm'].include?("977869")
+    assert_equal expected_start, medication.start_time
+    assert_equal expected_end, medication.end_time
   end
 end

--- a/test/unit/import/cat1/patient_importer_test.rb
+++ b/test/unit/import/cat1/patient_importer_test.rb
@@ -1,6 +1,16 @@
 require 'test_helper'
 
 class PatientImporterTest < MiniTest::Unit::TestCase
+
+  def test_care_goal
+    patient = build_record_from_xml('test/fixtures/cat1_fragments/care_goal_fragment.xml')
+    care_goal = patient.care_goals.first
+    assert care_goal.codes['SNOMED-CT'].include?('252465000')
+    assert care_goal.oid
+    expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('201101011400')
+    assert_equal expected_start, care_goal.start_time
+  end
+
   def test_ecog_status_importing
     patient = build_record_from_xml('test/fixtures/cat1_fragments/ecog_fragment.xml')
     ecog_status = patient.conditions.first
@@ -23,20 +33,8 @@ class PatientImporterTest < MiniTest::Unit::TestCase
     patient = build_record_from_xml('test/fixtures/cat1_fragments/physical_exam_performed_fragment.xml')
     physical_exam = patient.procedures.first
     assert physical_exam.codes['LOINC'].include?('8462-4')
-  end
-
-  def test_procedure_intolerance
-    patient = build_record_from_xml('test/fixtures/cat1_fragments/procedure_intolerance_fragment.xml')
-    procedure_intolerance = patient.allergies.first
-    assert procedure_intolerance.codes['CPT'].include?('90668')
-  end
-
-  def test_procedure_order
-    patient = build_record_from_xml('test/fixtures/cat1_fragments/procedure_order_fragment.xml')
-    procedure_order = patient.procedures.first
-    assert procedure_order.codes['CPT'].include?('90870')
-    expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('20110524094323')
-    assert_equal expected_start, procedure_order.start_time
+    assert physical_exam.oid
+    assert physical_exam.status
   end
 
   def test_procedure_performed
@@ -201,6 +199,7 @@ class PatientImporterTest < MiniTest::Unit::TestCase
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19910425090834')
     expected_end = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19910426051840')
     assert pe_finding.codes['LOINC'].include?('8480-6')
+    assert pe_finding.oid
     assert_equal expected_start, pe_finding.start_time
     assert_equal expected_end, pe_finding.end_time
   end
@@ -274,7 +273,6 @@ class PatientImporterTest < MiniTest::Unit::TestCase
   def build_record_from_xml(xml_file)
     doc = Nokogiri::XML(File.new(xml_file))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    
     patient = Record.new
     HealthDataStandards::Import::Cat1::PatientImporter.instance.import_sections(patient, doc)
     patient

--- a/test/unit/import/cat1/procedure_intolerance_importer_test.rb
+++ b/test/unit/import/cat1/procedure_intolerance_importer_test.rb
@@ -4,7 +4,11 @@ class ProcedureIntoleranceImporterTest < MiniTest::Unit::TestCase
   def test_procedure_intolerance
    	doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/procedure_intolerance_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    procedure_intolerance = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::ProcedureIntoleranceImporter.new, '2.16.840.1.113883.3.560.1.61').entry
+    nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
+    nrh.build_id_map(doc)
+    p_i = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::ProcedureIntoleranceImporter.new, '2.16.840.1.113883.3.560.1.61')
+    procedure_intolerances = p_i.package_entries(doc, nrh)
+    procedure_intolerance = procedure_intolerances[0]
     assert procedure_intolerance.codes['CPT'].include?('90668')
   end
 end

--- a/test/unit/import/cat1/procedure_intolerance_importer_test.rb
+++ b/test/unit/import/cat1/procedure_intolerance_importer_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class ProcedureIntoleranceImporterTest < MiniTest::Unit::TestCase
+  def test_procedure_intolerance
+   	doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/procedure_intolerance_fragment.xml'))
+    doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+    procedure_intolerance = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::ProcedureIntoleranceImporter.new, '2.16.840.1.113883.3.560.1.61').entry
+    assert procedure_intolerance.codes['CPT'].include?('90668')
+  end
+end

--- a/test/unit/import/cat1/procedure_order_importer_test.rb
+++ b/test/unit/import/cat1/procedure_order_importer_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class ProcedureOrderImporterTest < MiniTest::Unit::TestCase
+  def test_procedure_order
+   	doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/procedure_order_fragment.xml'))
+    doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+    procedure_order = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::ProcedureOrderImporter.new, '2.16.840.1.113883.3.560.1.62', 'ordered').entry
+    assert procedure_order.codes['CPT'].include?('90870')
+    assert procedure_order.oid
+    expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('20110524094323')
+    assert_equal expected_start, procedure_order.start_time
+  end
+end

--- a/test/unit/import/cat1/procedure_order_importer_test.rb
+++ b/test/unit/import/cat1/procedure_order_importer_test.rb
@@ -4,7 +4,11 @@ class ProcedureOrderImporterTest < MiniTest::Unit::TestCase
   def test_procedure_order
    	doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/procedure_order_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    procedure_order = HealthDataStandards::Import::Cat1::EntryPackage.new(doc, HealthDataStandards::Import::Cat1::ProcedureOrderImporter.new, '2.16.840.1.113883.3.560.1.62', 'ordered').entry
+    nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
+    nrh.build_id_map(doc)
+    p_o = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::ProcedureOrderImporter.new, '2.16.840.1.113883.3.560.1.62', 'ordered')
+    procedure_orders = p_o.package_entries(doc, nrh)
+    procedure_order = procedure_orders[0]
     assert procedure_order.codes['CPT'].include?('90870')
     assert procedure_order.oid
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('20110524094323')


### PR DESCRIPTION
EntryPackage object created - encapsulates all code for creating a complete QRDA entry with HQMF oid and proper status
Fixed an error in the JSON HQMF lookup file (wrong OID)
Added assertions for status codes and hqmf oids to QRDA import unit tests
Rewrote external Cat1 importer class test cases to leverage EntryPackage object
Wrote test case for care goals (hand-coded test XML fragment using QRDA spec)
