### PR TITLE
Include insurance provider codes when importing QRDA Cat 1 documents

### DIFF
--- a/lib/health-data-standards.rb
+++ b/lib/health-data-standards.rb
@@ -154,6 +154,7 @@ require_relative 'health-data-standards/import/cat1/entry_package'
 require_relative 'health-data-standards/import/cat1/lab_result_importer'
 require_relative 'health-data-standards/import/cat1/ecog_status_importer'
 require_relative 'health-data-standards/import/cat1/symptom_active_importer'
+require_relative 'health-data-standards/import/cat1/insurance_provider_importer'
 
 require_relative 'health-data-standards/models/cqm/aggregate_objects'
 require_relative 'health-data-standards/models/cqm/query_cache'

--- a/lib/health-data-standards/import/cat1/insurance_provider_importer.rb
+++ b/lib/health-data-standards/import/cat1/insurance_provider_importer.rb
@@ -1,0 +1,22 @@
+module HealthDataStandards
+  module Import
+    module Cat1
+      class InsuranceProviderImporter < CDA::SectionImporter
+      
+        def initialize
+          super(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.55']"))
+          @check_for_usable = false # needs to be this way becase InsuranceProvider does not respond
+                                    # to usable?
+        end
+
+        def create_entry(payer_element, nrh = CDA::NarrativeReferenceHandler.new)
+          ip = InsuranceProvider.new
+          value_element = payer_element.at_xpath('cda:value')
+          ip.codes = { 'SOP' => [value_element['code']] } if value_element
+          ip
+        end
+
+      end
+    end
+  end
+end

--- a/lib/health-data-standards/import/cat1/patient_importer.rb
+++ b/lib/health-data-standards/import/cat1/patient_importer.rb
@@ -64,6 +64,8 @@ module HealthDataStandards
 
           @section_importers[:social_history] = [generate_importer(TobaccoUseImporter, nil, '2.16.840.1.113883.3.560.1.1001', 'completed')]
 
+          @section_importers[:insurance_providers] = [generate_importer(InsuranceProviderImporter, nil, '2.16.840.1.113883.3.560.1.405')]
+
         end 
 
         def parse_cat1(doc)

--- a/lib/health-data-standards/models/insurance_provider.rb
+++ b/lib/health-data-standards/models/insurance_provider.rb
@@ -1,4 +1,4 @@
-class InsuranceProvider
+class InsuranceProvider < Entry
   include Mongoid::Document
   include ThingWithCodes
   

--- a/test/fixtures/cat1_fragments/insurance_provider_fragment.xml
+++ b/test/fixtures/cat1_fragments/insurance_provider_fragment.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="cda.xsl"?>
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:hl7-org:v3" xmlns:voc="urn:hl7-org:v3/voc" xmlns:sdtc="urn:hl7-org:sdtc">
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <entry>
+            <!-- Patient Characteristic Payer -->
+            <observation classCode="OBS" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+              <id root="1.3.6.1.4.1.115" extension="<%= entry.id %>"/>
+              <code code="48768-6" codeSystemName="LOINC" codeSystem="2.16.840.1.113883.6.1" displayName="Payment source"/> 
+              <statusCode code="completed"/>
+              <value code="349" codeSystem="2.16.840.1.113883.3.221.5" xsi:type="CD" sdtc:valueSet="2.16.840.1.114222.4.11.3591"><originalText></originalText></value>
+            </observation>            
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test/unit/import/cat1/insurance_provider_importer_test.rb
+++ b/test/unit/import/cat1/insurance_provider_importer_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class InsuranceProviderImporterTest < MiniTest::Unit::TestCase
+  
+  def test_insurance_providers
+    doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/insurance_provider_fragment.xml'))
+    doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+    nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
+    nrh.build_id_map(doc)
+    ipi = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::InsuranceProviderImporter.new, '2.16.840.1.113883.3.560.1.69', 'active')
+    insurance_providers = ipi.package_entries(doc, nrh)
+    assert_equal 1, insurance_providers.size
+    assert_equal({ 'SOP' => ['349'] }, insurance_providers.first.codes)
+  end
+end

--- a/test/unit/import/cat1/patient_importer_test.rb
+++ b/test/unit/import/cat1/patient_importer_test.rb
@@ -251,6 +251,12 @@ class PatientImporterTest < MiniTest::Unit::TestCase
     assert_equal expected_end, encounter.end_time
   end
 
+  def test_insurance_provider
+    patient = build_record_from_xml('test/fixtures/cat1_fragments/insurance_provider_fragment.xml')
+    ip = patient.insurance_providers.first
+    assert_equal({ 'SOP' => ['349'] }, ip.codes)
+  end
+
   private
 
   def build_record_from_xml(xml_file)


### PR DESCRIPTION
This commit modifies the QRDA Cat 1 patient importer to include insurance provider codes when importing. This is important to have in place for eventual completion of the QRDA Cat 3 export, which requires the insurance provider (payer) codes to be aggregated and included in the output.

Unit tests were added to ensure these changes are working properly.
