### PR TITLE
Ref #52, #54 Swapped order of elements, extra 'id' field

### DIFF
--- a/templates/cat3/_author.cat3.erb
+++ b/templates/cat3/_author.cat3.erb
@@ -17,8 +17,8 @@
         </assignedPerson> 
       <% elsif author.device %>
        <assignedAuthoringDevice>
-         <softwareName><%= author.device.name %></softwareName>
          <manufacturerModelName><%= author.device.model %></manufacturerModelName>
+         <softwareName><%= author.device.name %></softwareName>
        </assignedAuthoringDevice>
       <% end %> 
      

--- a/templates/cat3/show.cat3.erb
+++ b/templates/cat3/show.cat3.erb
@@ -41,7 +41,6 @@
   <!-- SHALL -->
   <custodian>
     <assignedCustodian>
-      <%== render :partial=>"id", :collection=>header.custodian.organization.ids, :id=>"identifier" %>
       <%== render :partial=>"organization", :locals=>{organization: header.custodian.organization} %>
     </assignedCustodian>
   </custodian>


### PR DESCRIPTION
Changed ordering of `softwareName` and `manufacturerModelName` to conform to Cypress schema.
