### PR TITLE
import entry.time (not entry.start_time) for procedure orders

### DIFF
--- a/lib/health-data-standards/import/cat1/procedure_order_importer.rb
+++ b/lib/health-data-standards/import/cat1/procedure_order_importer.rb
@@ -6,7 +6,7 @@ module HealthDataStandards
           super(entry_finder)
           @entry_class = Procedure
         end
-        
+
         def create_entry(entry_element, nrh = CDA::NarrativeReferenceHandler.new)
           procedure = super
           procedure.status_code = {'HL7 ActStatus' => ['ordered']}
@@ -20,7 +20,7 @@ module HealthDataStandards
 
         def extract_dates(parent_element, entry, element_name="author")
           if parent_element.at_xpath("cda:#{element_name}/cda:time/@value")
-            entry.start_time = HL7Helper.timestamp_to_integer(parent_element.at_xpath("cda:#{element_name}/cda:time")['value'])
+            entry.time = HL7Helper.timestamp_to_integer(parent_element.at_xpath("cda:#{element_name}/cda:time")['value'])
           end
         end
 

--- a/test/unit/import/cat1/procedure_order_importer_test.rb
+++ b/test/unit/import/cat1/procedure_order_importer_test.rb
@@ -12,6 +12,6 @@ class ProcedureOrderImporterTest < MiniTest::Unit::TestCase
     assert procedure_order.codes['CPT'].include?('90870')
     assert procedure_order.oid
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('20110524094323')
-    assert_equal expected_start, procedure_order.start_time
+    assert_equal expected_start, procedure_order.time
   end
 end


### PR DESCRIPTION
Measures that do time comparisons (e.g. 0441) expect an entry #time or both an #start_time and #end_time. Since the procedure order occurs at a single time-point, use the #time value.

See discussion at: https://groups.google.com/forum/#!topic/pophealth-dev/sT1KLFrtzKc
