### PR TITLE
import entry.time (not entry.start_time) for diagnostic study orders

### DIFF
--- a/lib/health-data-standards/import/cat1/diagnostic_study_order_importer.rb
+++ b/lib/health-data-standards/import/cat1/diagnostic_study_order_importer.rb
@@ -11,7 +11,7 @@ module HealthDataStandards
 
         def extract_dates(parent_element, entry, element_name="author")
           if parent_element.at_xpath("cda:#{element_name}/cda:time/@value")
-            entry.start_time = HL7Helper.timestamp_to_integer(parent_element.at_xpath("cda:#{element_name}/cda:time")['value'])
+            entry.time = HL7Helper.timestamp_to_integer(parent_element.at_xpath("cda:#{element_name}/cda:time")['value'])
           end
         end
       end

--- a/test/unit/import/cat1/diagnostic_study_order_test.rb
+++ b/test/unit/import/cat1/diagnostic_study_order_test.rb
@@ -11,6 +11,6 @@ class DiagnosticStudyOrderImporterTest < MiniTest::Unit::TestCase
     order = orders[0]
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19891215072420')
     assert order.codes['LOINC'].include?("69399-4")
-    assert_equal expected_start, order.start_time
+    assert_equal expected_start, order.time
   end
 end


### PR DESCRIPTION
Measures that do time comparisons (e.g. 0376) expect an entry #time or both an #start_time and #end_time. Since the diagnostic study order occurs at a single time-point, use the #time value.
