### PR TITLE
call population_count with 2 arguments

### DIFF
--- a/templates/cat3/_continuous_variable_value.cat3.erb
+++ b/templates/cat3/_continuous_variable_value.cat3.erb
@@ -5,10 +5,10 @@
       <originalText>Time Difference</originalText>
     </code>
     <statusCode code="completed"/>
-    <value xsi:type="PQ" value="<%= population.population_count('OBSERV') %>" unit="min"/>
-    <methodCode code="MEDIAN" 
-                displayName="Median" 
-                codeSystem="2.16.840.1.113883.5.84" 
+    <value xsi:type="PQ" value="<%= population.population_count('OBSERV', population.population_id('OBSERV')) %>" unit="min"/>
+    <methodCode code="MEDIAN"
+                displayName="Median"
+                codeSystem="2.16.840.1.113883.5.84"
                 codeSystemName="ObservationMethod"/>
     <reference typeCode="REFR">
       <!-- reference to the relevant measure observation in the eMeasure -->


### PR DESCRIPTION
The module method HealthDataStandards::CQM::PopulationSelectors#population_count expects two arguments. Closes #61
