### PR TITLE
ignore blank top level populations in measure section

### DIFF
--- a/templates/cat3/show.cat3.erb
+++ b/templates/cat3/show.cat3.erb
@@ -129,7 +129,7 @@ Measure Section
               <%== render :partial => 'performance_rate', :locals => {:aggregate_count => result} %>
               </component>
               <% end -%>
-              <% result.top_level_populations.each do |pop| 
+              <% result.top_level_populations.compact.each do |pop|
                    unless pop.type == 'OBSERV' -%>
               <component>
               <%== render :partial => 'measure_data', :locals => {:aggregate_count => result, :population_type => pop.type, :population_id => pop.id} %>


### PR DESCRIPTION
Blank top_level_populations cause cat3 export to fail. This pull request filters out those blank entries without investigating the source.
