### PR TITLE
removal time for medical equipment

### DIFF
--- a/lib/health-data-standards/import/cda/medical_equipment_importer.rb
+++ b/lib/health-data-standards/import/cda/medical_equipment_importer.rb
@@ -13,6 +13,7 @@ module HealthDataStandards
           medical_equipment = super
           extract_manufacturer(entry_element, medical_equipment)
           extract_anatomical_structure(entry_element, medical_equipment)
+          extract_removal_time(entry_element, medical_equipment)
           medical_equipment
         end
 
@@ -21,7 +22,13 @@ module HealthDataStandards
           entry.manufacturer = manufacturer.strip if manufacturer
         end
 
-        def extract_anatomical_structure(entry_element, entry) 
+        def extract_removal_time(entry_element, entry)
+          if entry_element.at_xpath("cda:effectiveTime/cda:high")
+            entry.removal_time = HL7Helper.timestamp_to_integer(entry_element.at_xpath("cda:effectiveTime/cda:high")['value'])
+          end
+        end
+
+        def extract_anatomical_structure(entry_element, entry)
           site = entry_element.at_xpath(@anatomical_xpath)
           if site
             entry.anatomical_structure = {CodeSystemHelper.code_system_for(site['codeSystem']) => [site['code']]}


### PR DESCRIPTION
Some measures (e.g. 0453) expect medical equipment entries to have a removalTime. removalTime is generated as the "high" value in

https://github.com/projectcypress/health-data-standards/blob/master/templates/cat1/_2.16.840.1.113883.10.20.24.3.7.cat1.erb#L14

so extracting that value seems reasonable.
