### PR TITLE
correct xpath for encounter and reason. add admit_time to encounter

### DIFF
--- a/lib/health-data-standards/import/cda/encounter_importer.rb
+++ b/lib/health-data-standards/import/cda/encounter_importer.rb
@@ -3,10 +3,9 @@ module HealthDataStandards
     module CDA
       # TODO Extract Discharge Disposition
       class EncounterImporter < SectionImporter
-    
-        def initialize(entry_finder=EntryFinder.new("//cda:section[cda:templateId/@root='2.16.840.1.113883.3.88.11.83.127']/cda:entry/cda:encounter"))
+        def initialize(entry_finder=EntryFinder.new("//cda:section[cda:templateId/@root='2.16.840.1.113883.3.88.11.83.127']/cda:entry/cda:encounter or //cda:section[cda:templateId/@root='2.16.840.1.113883.10.20.17.2.4']/cda:entry/cda:encounter"))
           super(entry_finder)
-          @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:act"
+          @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation"
           @entry_class = Encounter
         end
         
@@ -53,6 +52,7 @@ module HealthDataStandards
         end
     
         def extract_admission(parent_element, encounter)
+          encounter.admit_time = encounter.start_time
           encounter.admit_type = extract_code(parent_element, "./cda:priorityCode")
         end
 


### PR DESCRIPTION
The cat1 encounter importer is using a c32 oid, but the export is using a new oid:

https://github.com/projectcypress/health-data-standards/blob/master/templates/cat1/_patient_data.cat1.erb#L4

Some measures (e.g. 0371, 0437, 0438, 0639) require admitTime to be set. admitTime is generated as the "low" value in:

https://github.com/projectcypress/health-data-standards/blob/master/templates/cat1/_2.16.840.1.113883.10.20.24.3.23.cat1.erb#L14

so extracting that value seems reasonable.
