### PR TITLE
aggregate and report measures with sub-measures (via #sub_id)

### DIFF
--- a/lib/health-data-standards/export/cat_3.rb
+++ b/lib/health-data-standards/export/cat_3.rb
@@ -12,7 +12,12 @@ module HealthDataStandards
       def export(measures, header, effective_date, start_date, end_date, filter=nil,test_id=nil)
         results = {}
         measures.each do |measure|
-          results[measure['hqmf_id']] = HealthDataStandards::CQM::QueryCache.aggregate_measure(measure['hqmf_id'], effective_date, filter, test_id)
+          if measure['sub_id']
+            results[measure['hqmf_id']] ||= {}
+            results[measure['hqmf_id']][measure['sub_id']] = HealthDataStandards::CQM::QueryCache.aggregate_measure(measure['hqmf_id'], measure['sub_id'], effective_date, filter, test_id)
+          else
+            results[measure['hqmf_id']] = HealthDataStandards::CQM::QueryCache.aggregate_measure(measure['hqmf_id'], nil, effective_date, filter, test_id)
+          end
         end
         @rendering_context.render(:template => 'show', 
                                   :locals => {:measures => measures, :start_date => start_date, 

--- a/lib/health-data-standards/models/cqm/query_cache.rb
+++ b/lib/health-data-standards/models/cqm/query_cache.rb
@@ -21,8 +21,8 @@ module HealthDataStandards
       field :OBSERV, type: Float
       field :supplemental_data, type: Hash
 
-      def self.aggregate_measure(measure_id, effective_date, filter=nil, test_id=nil)
-        cache_entries = self.where(effective_date: effective_date, measure_id: measure_id, test_id: test_id, filter: filter)
+      def self.aggregate_measure(measure_id, sub_id, effective_date, filter=nil, test_id=nil)
+        cache_entries = self.where(effective_date: effective_date, measure_id: measure_id, sub_id: sub_id, test_id: test_id, filter: filter)
         aggregate_count = AggregateCount.new
         aggregate_count.measure_id = measure_id
         cache_entries.each do |cache_entry|

--- a/templates/cat3/show.cat3.erb
+++ b/templates/cat3/show.cat3.erb
@@ -121,10 +121,8 @@ Measure Section
                   <versionNumber value="1"/>
                 </externalDocument>
               </reference>
-             
-              <% result = results[measure['hqmf_id']]
-                 unless result.is_cv? || result.multiple_population_types?
-              -%>
+              <% result = measure['sub_id'] ? results[measure['hqmf_id']][measure['sub_id']] : results[measure['hqmf_id']] -%>
+              <% unless result.is_cv? || result.multiple_population_types? -%>
               <component>
               <%== render :partial => 'performance_rate', :locals => {:aggregate_count => result} %>
               </component>
@@ -134,8 +132,8 @@ Measure Section
               <component>
               <%== render :partial => 'measure_data', :locals => {:aggregate_count => result, :population_type => pop.type, :population_id => pop.id} %>
               </component>
-              <%   end
-                 end -%>
+                <% end -%>
+              <% end -%>
             </organizer>
           </entry>
           <% end %>

--- a/test/unit/models/cqm/query_cache_test.rb
+++ b/test/unit/models/cqm/query_cache_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class QueryCacheTest < MiniTest::Unit::TestCase
   def test_aggregate_measure
     collection_fixtures('query_cache')
-    aggregate_count = HealthDataStandards::CQM::QueryCache.aggregate_measure("8A4D92B2-397A-48D2-0139-C648B33D5582" ,1356998340)
+    aggregate_count = HealthDataStandards::CQM::QueryCache.aggregate_measure("8A4D92B2-397A-48D2-0139-C648B33D5582", nil ,1356998340)
     ipp_pop = aggregate_count.top_level_populations.find{|p| p.type == 'IPP'}
     assert_equal 3, ipp_pop.value
     assert_equal "155518F5-8B70-49AB-A3CB-E53037D5442D", ipp_pop.id


### PR DESCRIPTION
Previously, sub-measures were being ignored. Use the sub_id to retrieve and report on them separately.
