### PR TITLE
Fix Test Result whitespace for PQ values

### DIFF
--- a/templates/cat1/_result_value.cat1.erb
+++ b/templates/cat1/_result_value.cat1.erb
@@ -14,7 +14,7 @@
 	<%== code_display(ev, 'preferred_code_sets' => ['LOINC', 'SNOMED-CT', 'ICD-9-CM', 'ICD-10-CM'], 'tag_name' => 'value', 'extra_content' => extra_content) %>
 	<%   elsif ev.respond_to?(:scalar) -%>
 	<%     if is_num?(ev.scalar) -%>
-	<value xsi:type="PQ" value="<%= ev.scalar %>" <% if ev.units && (ev.units != "") -%>unit="<%= ev.units %>"<% end -%>/>
+	<value xsi:type="PQ" value="<%= ev.scalar.to_s.strip %>" <% if ev.units && (ev.units != "") -%>unit="<%= ev.units %>"<% end -%>/>
 	<%     elsif is_bool?(ev.scalar)%>
 	<value xsi:type="BL" value="<%= ev.scalar %>" />
 	<%     else -%>


### PR DESCRIPTION
PQ values contain white space (value="150 ") for some patients, the easiest way to fix this is to strip whitespace form the value in the template
