### PR TITLE
modifying templates to support multiple result values

### DIFF
--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.20.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.20.cat1.erb
@@ -1,3 +1,6 @@
+<% vals = entry.values.empty? ? [nil] : entry.values 
+   vals.each do |value| 
+ %>   
 <entry>
   <observation classCode="OBS" moodCode="EVN" <%== negation_indicator(entry) %>>
     <!-- Consolidated Result Observation templateId (Implied Template) -->
@@ -14,7 +17,8 @@
       <low <%= value_or_null_flavor(entry.start_time) %>/>
       <high <%= value_or_null_flavor(entry.end_time) %>/>
     </effectiveTime>
-    <%== render(:partial => 'result_value', :locals => {:values => [entry.values.first], :result_oids=>result_oids}) %>
+    <%== render(:partial => 'result_value', :locals => {:values => [value], :result_oids=>result_oids}) %>
     <%== render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
   </observation>
 </entry>
+<% end %>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.28.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.28.cat1.erb
@@ -1,3 +1,6 @@
+<% vals = entry.values.empty? ? [nil] : entry.values 
+   vals.each do |value| 
+ %>   
 <entry>
   <observation classCode="OBS" moodCode="EVN">
     <!-- Functional Status Result Observation (consolidation) template -->
@@ -15,6 +18,7 @@
     </effectiveTime>
 
     <!-- Result -->
-    <%== render(:partial => 'result_value', :locals => {:values => [entry.values.first], :result_oids=>result_oids}) %>
+    <%== render(:partial => 'result_value', :locals => {:values => [value], :result_oids=>result_oids}) %>
   </observation>
 </entry>
+<% end %>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.40.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.40.cat1.erb
@@ -1,3 +1,6 @@
+<% vals = entry.values.empty? ? [nil] : entry.values 
+   vals.each do |value| 
+ %>   
 <entry>
   <!--Laboratory test, result -->
   <observation classCode="OBS" moodCode="EVN">
@@ -13,6 +16,7 @@
       <low <%= value_or_null_flavor(entry.start_time) %>/>
       <high <%= value_or_null_flavor(entry.end_time) %>/>
     </effectiveTime>
-    <%== render(:partial => 'result_value', :locals => {:values => [entry.values.first], :result_oids=>result_oids}) %>
+    <%== render(:partial => 'result_value', :locals => {:values => [value], :result_oids=>result_oids}) %>
   </observation>
 </entry>
+<% end %>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.57.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.57.cat1.erb
@@ -1,3 +1,6 @@
+<% vals = entry.values.empty? ? [nil] : entry.values 
+   vals.each do |value| 
+ %>   
 <entry>
   <!-- Physical Exam Finding -->
   <observation classCode="OBS" moodCode="EVN">
@@ -13,6 +16,7 @@
       <low <%= value_or_null_flavor(entry.start_time) %>/>
       <high <%= value_or_null_flavor(entry.end_time) %>/>
     </effectiveTime>
-    <%== render(:partial => 'result_value', :locals => {:values => [entry.values.first], :result_oids=>result_oids}) %>
+    <%== render(:partial => 'result_value', :locals => {:values => [value], :result_oids=>result_oids}) %>
   </observation>
 </entry>
+<% end %>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.59.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.59.cat1.erb
@@ -1,3 +1,6 @@
+<% vals = entry.values.empty? ? [nil] : entry.values 
+   vals.each do |value| 
+ %>   
 <entry>
   <observation classCode="OBS" moodCode="EVN" <%== negation_indicator(entry) %>>
     <!-- Procedure Activity Procedure (Consolidation) template -->
@@ -12,6 +15,7 @@
       <low <%= value_or_null_flavor(entry.start_time) %>/>
       <high <%= value_or_null_flavor(entry.end_time) %>/>
     </effectiveTime>
-    <%== render(:partial => 'result_value', :locals => {:values => [entry.values.first], :result_oids=>result_oids}) %>
+    <%== render(:partial => 'result_value', :locals => {:values => [value], :result_oids=>result_oids}) %>
   </observation>
 </entry>
+<% end %>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.66.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.66.cat1.erb
@@ -1,6 +1,6 @@
-
-<% vals = entry.values || [nil]
-   vals.each do |value| %>
+<% vals = entry.values.empty? ? [nil] : entry.values 
+   vals.each do |value| 
+ %>   
 <entry>
   <procedure classCode="PROC" moodCode="EVN">
     <!-- Consolidated Procedure Activity Procedure TemplateId 

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.69.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.69.cat1.erb
@@ -1,5 +1,6 @@
-<% vals = entry.values || [nil]
-   vals.each do |value| %>
+<% vals = entry.values.empty? ? [nil] : entry.values 
+   vals.each do |value| 
+ %>   
 <entry>
   <observation classCode="OBS" moodCode="EVN" <%== negation_indicator(entry) %>>
     <!-- Consolidation Assessment Scale Observation templateId -->


### PR DESCRIPTION
For all of the templates that support values modifying to support looping over the values to create an instance for each one, until the CAT I spec is updated to support multiple values per entry.
