### PR TITLE
add admit_time to encounter importer

### DIFF
--- a/lib/health-data-standards/import/cda/encounter_importer.rb
+++ b/lib/health-data-standards/import/cda/encounter_importer.rb
@@ -53,6 +53,7 @@ module HealthDataStandards
         end
     
         def extract_admission(parent_element, encounter)
+          encounter.admit_time = encounter.start_time
           encounter.admit_type = extract_code(parent_element, "./cda:priorityCode")
         end
 

--- a/test/unit/import/cat1/patient_importer_test.rb
+++ b/test/unit/import/cat1/patient_importer_test.rb
@@ -250,6 +250,8 @@ class PatientImporterTest < MiniTest::Unit::TestCase
     assert encounter.discharge_disposition["code"].include?('306699001')
     assert_equal expected_start, encounter.start_time
     assert_equal expected_end, encounter.end_time
+    assert_equal expected_start, encounter.admit_time
+    assert_equal expected_end, encounter.discharge_time
   end
 
   def test_insurance_provider


### PR DESCRIPTION
Some measures (e.g. 0371, 0437, 0438, 0639) require admitTime to be set. admitTime is generated as the "low" value in:

https://github.com/projectcypress/health-data-standards/blob/master/templates/cat1/_2.16.840.1.113883.10.20.24.3.23.cat1.erb#L14

so extracting that value seems reasonable.
