### PR TITLE
Fix for HealthDataStandards::Import::Cat1::PatientImporter#get_clinical_trial_participantrticipant always returning true. Closes #91

### DIFF
--- a/lib/health-data-standards/import/cat1/patient_importer.rb
+++ b/lib/health-data-standards/import/cat1/patient_importer.rb
@@ -90,7 +90,7 @@ module HealthDataStandards
 
         def get_clinical_trial_participant(record, doc)
           entry_elements = doc.xpath("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.51']")
-          record.clinicalTrialParticipant = true unless entry_elements.nil? 
+          record.clinicalTrialParticipant = true unless entry_elements.blank?
         end
 
         def get_patient_expired(record, doc)

--- a/test/unit/import/cat1/patient_importer_test.rb
+++ b/test/unit/import/cat1/patient_importer_test.rb
@@ -211,6 +211,14 @@ class PatientImporterTest < MiniTest::Unit::TestCase
     assert patient.clinicalTrialParticipant
   end
 
+  def test_not_clinical_trial_participant
+    patient = Record.new
+    doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/care_goal_fragment.xml'))
+    doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+    HealthDataStandards::Import::Cat1::PatientImporter.instance.get_clinical_trial_participant(patient, doc)
+    assert !patient.clinicalTrialParticipant
+  end
+
   def test_diagnostic_study_result
     patient = build_record_from_xml('test/fixtures/cat1_fragments/diagnostic_study_result_fragment.xml')
     diag_study_result = patient.results.first


### PR DESCRIPTION
HealthDataStandards::Import::Cat1::PatientImporter#get_clinical_trial_participantrticipant always returns true. Fix this by checking .blank? (empty array) instead of .nil? on the nokogiri xpath query
