### PR TITLE
cumulative medication duration

### DIFF
--- a/lib/health-data-standards/import/cat1/medication_active_importer.rb
+++ b/lib/health-data-standards/import/cat1/medication_active_importer.rb
@@ -5,11 +5,14 @@ module HealthDataStandards
 
         def initialize
           super(CDA::EntryFinder.new("//cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.41']"))
+          @cumulative_medication_duration_xpath = ".//cda:observation[cda:templateId/@root = '2.16.840.1.113883.3.560.1.1033.3']/cda:value"
         end
 
         def create_entry(entry_element, nrh = CDA::NarrativeReferenceHandler.new)
           medication = super
           calculate_cumulative_medication_duration(medication)
+          # a provided, pre-calculated cumulative medication duration overrides a calculated duration
+          extract_cumulative_medication_duration(entry_element, medication)
           medication
         end
 
@@ -19,6 +22,13 @@ module HealthDataStandards
           if medication.start_time.present? && medication.end_time.present?
             duration_in_days = ((medication.end_time - medication.start_time) / (60*60*24)).floor + 1
             medication.cumulative_medication_duration = {'scalar' => duration_in_days, 'units' => 'days'}
+          end
+        end
+
+        def extract_cumulative_medication_duration(entry_element, medication)
+          if duration_element = entry_element.at_xpath(@cumulative_medication_duration_xpath)
+            medication.cumulative_medication_duration = {'scalar' => duration_element['value'],
+                                                          'units' => duration_element['unit']}
           end
         end
       end

--- a/templates/cat1/_medication_details.cat1.erb
+++ b/templates/cat1/_medication_details.cat1.erb
@@ -10,6 +10,18 @@
            />
 <% end -%>
 
+<!-- Attribute: dose -->
 <% if entry.respond_to?(:dose) && entry.dose.present? -%>
 <doseQuantity value="<%= entry.dose['value']%>"/>
+<% end -%>
+
+<!-- Attribute: cumulativeMedicationDuration -->
+<% if entry.respond_to?(:cumulativeMedicationDuration) && entry.cumulativeMedicationDuration.present? -%>
+<sourceOf typeCode="SUBJ">
+  <observation classCode="OBS" moodCode="EVN" isCriterionInd="true">
+    <templateId root="2.16.840.1.113883.3.560.1.1033.3"/>
+    <code code="363819003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="cumulative medication duration"/>
+    <value xsi:type="IVL_PQ" value="<%= entry.cumulativeMedicationDuration['scalar'] -%>" unit="<%= entry.cumulativeMedicationDuration['units'] -%>"/>
+  </observation>
+</sourceOf>
 <% end -%>

--- a/test/fixtures/cat1_fragments/medication_active_fragment.xml
+++ b/test/fixtures/cat1_fragments/medication_active_fragment.xml
@@ -19,11 +19,18 @@
                   <low value='19890509170647'/>
                   <high value='19890509173724'/>
               </effectiveTime>
-              
-              
+
+
               <!-- Attribute: dose -->
 
-
+              <!-- Attribute: cumulativeMedicationDuration -->
+              <sourceOf typeCode="SUBJ">
+                <observation classCode="OBS" moodCode="EVN" isCriterionInd="true">
+                  <templateId root="2.16.840.1.113883.3.560.1.1033.3"/>
+                  <code code="363819003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="cumulative medication duration"/>
+                  <value xsi:type="IVL_PQ" value="5" unit="days"/>
+                </observation>
+              </sourceOf>
 
               <consumable>
                 <manufacturedProduct classCode="MANU">

--- a/test/unit/import/cat1/medication_active_importer_test.rb
+++ b/test/unit/import/cat1/medication_active_importer_test.rb
@@ -16,6 +16,6 @@ class MedicationActiveImporterTest < MiniTest::Unit::TestCase
     assert medication.codes['RxNorm'].include?('866439')
     assert_equal expected_start, medication.start_time
     assert_equal expected_end, medication.end_time
-    assert_equal 1, medication.cumulative_medication_duration['scalar']
+    assert_equal "5", medication.cumulative_medication_duration['scalar']
   end
 end


### PR DESCRIPTION
As discussed here: https://groups.google.com/d/topic/pophealth-dev/1Iw48pRe8cw/discussion

A cumulative medication duration is sometimes provided and could be different than the difference between the start_time attributes of medication entries, or the difference between start_time and end_time attributes in a single medication entry. If the duration is provided, it must have been generated by information that exists outside of the scope of start_time and end_time.

Import a provided cumulative medication duration if provided and override a calculated duration.
