### PR TITLE
Adding CDA identifiers to providers

### DIFF
--- a/lib/health-data-standards/import/provider_import_utils.rb
+++ b/lib/health-data-standards/import/provider_import_utils.rb
@@ -6,10 +6,11 @@ module ProviderImportUtils
   end
   
   def find_or_create_provider(provider_hash)
-    provider = Provider.where(npi: provider_hash[:npi]).first if provider_hash[:npi] && !provider_hash[:npi].empty?
+    provider = Provider.by_npi(provider_hash[:npi]).first if provider_hash[:npi] && !provider_hash[:npi].empty?
     unless provider
       if provider_hash[:npi]
         provider = Provider.create(provider_hash)
+        provider.npi = provider_hash[:npi]
       else
         provider ||= Provider.resolve_provider(provider_hash) if Provider.respond_to? :resolve_provider
         

--- a/lib/health-data-standards/models/cda_identifier.rb
+++ b/lib/health-data-standards/models/cda_identifier.rb
@@ -3,7 +3,7 @@ class CDAIdentifier
 
   field :root, type: String
   field :extension, type: String
-  embedded_in :entry
+  embedded_in :cda_identifiable, polymorphic: true
 
   def ==(comparison_object)
     if comparison_object.respond_to?(:root) && comparison_object.respond_to?(:extension)

--- a/lib/health-data-standards/models/entry.rb
+++ b/lib/health-data-standards/models/entry.rb
@@ -6,7 +6,7 @@ class Entry
   # embedded_in :entry_list, polymorphic: true
   
   embedded_in :record
-  embeds_one :cda_identifier, class_name: "CDAIdentifier"
+  embeds_one :cda_identifier, class_name: "CDAIdentifier", as: :cda_identifiable
   embeds_many :values, class_name: "ResultValue"
   
   field :description, type: String

--- a/lib/health-data-standards/models/provider.rb
+++ b/lib/health-data-standards/models/provider.rb
@@ -10,7 +10,7 @@ class Provider
   validates_uniqueness_of :npi, allow_blank: true
   
   embeds_one :organization
-
+  embeds_many :cda_identifiers, class_name: "CDAIdentifier", as: :cda_identifiable
 
   def records(effective_date=nil)
     Record.by_provider(self, effective_date)

--- a/lib/health-data-standards/models/provider.rb
+++ b/lib/health-data-standards/models/provider.rb
@@ -2,8 +2,9 @@ class Provider
   include Personable
   include Mongoid::Tree
   
-  field :npi         , type: String
-  field :tin         , type: String
+  NPI_OID = '2.16.840.1.113883.4.6'
+  TAX_ID_OID = '2.16.840.1.113883.4.2'
+
   field :specialty   , type: String
   field :phone       , type: String
   
@@ -11,6 +12,26 @@ class Provider
   
   embeds_one :organization
   embeds_many :cda_identifiers, class_name: "CDAIdentifier", as: :cda_identifiable
+
+  scope :by_npi, ->(an_npi){ where("cda_identifiers.root" => NPI_OID, "cda_identifiers.extension" => an_npi)}
+
+  def npi=(an_npi)
+    self.cda_identifiers << CDAIdentifier.new(root: NPI_OID, extension: an_npi)
+  end
+
+  def npi
+    cda_id_npi = self.cda_identifiers.where(root: NPI_OID).first
+    cda_id_npi ? cda_id_npi.extension : nil
+  end
+
+  def tin=(a_tin)
+    self.cda_identifiers << CDAIdentifier.new(root: TAX_ID_OID, extension: a_tin)
+  end
+
+  def tin
+    cda_id_tin = self.cda_identifiers.where(root: TAX_ID_OID).first
+    cda_id_tin ? cda_id_tin.extension : nil
+  end
 
   def records(effective_date=nil)
     Record.by_provider(self, effective_date)

--- a/test/unit/import/ccr/provider_importer_test.rb
+++ b/test/unit/import/ccr/provider_importer_test.rb
@@ -13,13 +13,13 @@ module CCR
     def test_provider_extraction
      results =  @pi.extract_providers(@ccr)
      
-     npi_provider = results.map(&:provider).detect { |pv| pv[:npi] != nil }
+     npi_provider = results.map(&:provider).detect { |pv| pv.npi != nil }
      
-     refute_nil npi_provider
+     assert npi_provider
 
-     assert_equal "Sam", npi_provider[:given_name]
-     assert_equal "Willis", npi_provider[:family_name]
-     assert_equal "808401234567893", npi_provider[:npi]
+     assert_equal "Sam", npi_provider.given_name
+     assert_equal "Willis", npi_provider.family_name
+     assert_equal "808401234567893", npi_provider.npi
     end
   end
 end


### PR DESCRIPTION
Making CDAIdentifier embedding polymorphic. This ripples through to
entry. Providers can now have many CDAIdentifiers. This is to support
identifiers for providers in QRDA Cat I.
