### PR TITLE
Now exporting providers in QRDA Cat I

### DIFF
--- a/templates/cat1/_providers.cat1.erb
+++ b/templates/cat1/_providers.cat1.erb
@@ -1,0 +1,55 @@
+<documentationOf typeCode="DOC">
+  <serviceEvent classCode="PCPR"> <!-- care provision -->
+  <% if patient.provider_performances.empty? -%>
+    <!-- No provider data found in the patient record
+         putting in a fake provider -->
+    <effectiveTime>
+      <low value="20020716"/>
+      <high value="<%= Time.now.utc.to_formatted_s(:number) %>"/>
+    </effectiveTime>
+    <!-- You can include multiple performers, each with an NPI, TIN, CCN. -->
+    <performer typeCode="PRF"> 
+      <time>
+        <low value="20020716"/>
+        <high value="<%= Time.now.utc.to_formatted_s(:number) %>"/>
+      </time>
+      <assignedEntity>
+        <!-- This is the provider NPI -->
+        <id root="2.16.840.1.113883.4.6" extension="111111111" /> 
+        <representedOrganization>
+          <!-- This is the organization TIN -->
+          <id root="2.16.840.1.113883.4.2" extension="1234567" /> 
+          <!-- This is the organization CCN -->
+          <id root="2.16.840.1.113883.4.336" extension="54321" /> 
+        </representedOrganization>
+      </assignedEntity>
+    </performer>
+  <% else -%>
+    <% patient.provider_performances.each do |pp| -%>
+      <effectiveTime>
+        <low <%= value_or_null_flavor(pp.start_date) %>/>
+        <high <%= value_or_null_flavor(pp.end_date) %>/>
+      </effectiveTime>
+      <!-- You can include multiple performers, each with an NPI, TIN, CCN. -->
+      <performer typeCode="PRF"> 
+        <time>
+          <low <%= value_or_null_flavor(pp.start_date) %>/>
+          <high <%= value_or_null_flavor(pp.end_date) %>/>
+        </time>
+        <assignedEntity>
+          <% pp.provider.cda_identifiers.each do |cda_id| -%>
+            <% unless cda_id.root.eql? '2.16.840.1.113883.4.2' -%>
+          <id root="<%= cda_id.root %>" extension="<%= cda_id.root %>" /> 
+            <% end -%>
+          <% end -%>
+          <representedOrganization>
+            <% if pp.provider.tin -%>
+            <id root="2.16.840.1.113883.4.2" extension="<%= pp.provider.tin %>" /> 
+            <% end -%>
+          </representedOrganization>
+        </assignedEntity>
+      </performer>
+    <% end -%>
+  <% end -%>
+  </serviceEvent>
+</documentationOf>

--- a/templates/cat1/_providers.cat1.erb
+++ b/templates/cat1/_providers.cat1.erb
@@ -43,8 +43,10 @@
             <% end -%>
           <% end -%>
           <representedOrganization>
-            <% if pp.provider.tin -%>
-            <id root="2.16.840.1.113883.4.2" extension="<%= pp.provider.tin %>" /> 
+            <% pp.provider.cda_identifiers.each do |cda_id| -%>
+            <% if cda_id.root.eql?('2.16.840.1.113883.4.2') -%>
+            <id root="2.16.840.1.113883.4.2" extension="<%= cda_id.extension %>" /> 
+            <% end -%>  
             <% end -%>
           </representedOrganization>
         </assignedEntity>

--- a/templates/cat1/show.cat1.erb
+++ b/templates/cat1/show.cat1.erb
@@ -86,35 +86,7 @@
       </representedOrganization>
     </assignedEntity>
   </legalAuthenticator>
-
-  <!-- TODO: This is where the provider information will go.
-       It is currently hard coded, but should be replaced with the providers
-       and the time over which they are performing. --> 
-  <documentationOf typeCode="DOC">
-    <serviceEvent classCode="PCPR"> <!-- care provision -->
-      <effectiveTime>
-        <low value="20020716"/>
-        <high value="<%= Time.now.utc.to_formatted_s(:number) %>"/>
-      </effectiveTime>
-      <!-- You can include multiple performers, each with an NPI, TIN, CCN. -->
-      <performer typeCode="PRF"> 
-        <time>
-          <low value="20020716"/>
-          <high value="<%= Time.now.utc.to_formatted_s(:number) %>"/>
-        </time>
-        <assignedEntity>
-          <!-- This is the provider NPI -->
-          <id root="2.16.840.1.113883.4.6" extension="111111111" /> 
-          <representedOrganization>
-            <!-- This is the organization TIN -->
-            <id root="2.16.840.1.113883.4.2" extension="1234567" /> 
-            <!-- This is the organization CCN -->
-            <id root="2.16.840.1.113883.4.336" extension="54321" /> 
-          </representedOrganization>
-        </assignedEntity>
-      </performer>
-    </serviceEvent>
-  </documentationOf>
+  <%== render :partial => 'providers', :locals => {:patient => patient} %>
   <component>
     <structuredBody>
       <%== render :partial => 'measures', :locals => {:measures => measures} %>

--- a/test/unit/export/cat_1_test.rb
+++ b/test/unit/export/cat_1_test.rb
@@ -8,6 +8,13 @@ class Cat1Test < MiniTest::Unit::TestCase
       collection_fixtures('records')
       @patient = Record.where({first: "Barry"}).first
 
+      pp = ProviderPerformance.new(start_date: Time.new(2012).to_i, end_date: Time.new(2012, 12, 31).to_i)
+      provider = Provider.new(first: 'Hiram', last: 'McDaniels')
+      provider.npi = '111111111'
+      provider.save!
+      pp.provider = provider
+      @patient.provider_performances << pp
+
       @start_date = Time.now.years_ago(1)
       @end_date = Time.now
 
@@ -25,6 +32,7 @@ class Cat1Test < MiniTest::Unit::TestCase
      xsd = Nokogiri::XML::Schema(open("./resources/schema/infrastructure/cda/CDA_SDTC.xsd"))
      valid_measures = @measures.select { |m| m.hqmf_id.length > 4 } #make sure there is a valid hqmf_id
      Record.all.each do |record|
+      puts "Testing Cat I for #{record.first} #{record.last}"
       doc = Nokogiri::XML(HealthDataStandards::Export::Cat1.new.export(record,valid_measures,@start_date,@end_date))
       assert_equal [], xsd.validate(doc), "Invalid Cat I for #{record.first} #{record.last}" 
     end  


### PR DESCRIPTION
Previously, QRDA Cat I would only export a placeholder provider. Now
if a Record has ProviderPerformances, it will export those providers.
