### PR TITLE
Fixing assignment of NPIs to a provider

### DIFF
--- a/lib/health-data-standards/models/provider.rb
+++ b/lib/health-data-standards/models/provider.rb
@@ -16,7 +16,13 @@ class Provider
   scope :by_npi, ->(an_npi){ where("cda_identifiers.root" => NPI_OID, "cda_identifiers.extension" => an_npi)}
 
   def npi=(an_npi)
-    self.cda_identifiers << CDAIdentifier.new(root: NPI_OID, extension: an_npi)
+    cda_id_npi = self.cda_identifiers.where(root: NPI_OID).first
+    if cda_id_npi
+      cda_id_npi.extension = an_npi
+      cda_id_npi.save!
+    else
+      self.cda_identifiers << CDAIdentifier.new(root: NPI_OID, extension: an_npi)
+    end
   end
 
   def npi

--- a/test/unit/models/provider_test.rb
+++ b/test/unit/models/provider_test.rb
@@ -10,4 +10,14 @@ class ProviderTest < MiniTest::Unit::TestCase
     refute Provider.valid_npi?('1010101010')
     refute Provider.valid_npi?('abcdefghij')
   end
+
+  def test_npi_assignment
+    # A provider should only have a single NPI
+    p = Provider.new
+    p.npi = '1234567893'
+    assert_equal 1, p.cda_identifiers.length
+    p.npi = '808401234567893'
+    assert_equal 1, p.cda_identifiers.length
+    assert_equal '808401234567893', p.npi
+  end
 end


### PR DESCRIPTION
A provider should only have a singe NPI. This code makes sure that is
the case.
