### PR TITLE
Fixing some typos that cause bad behavior

### DIFF
--- a/lib/health-data-standards/import/bulk_record_importer.rb
+++ b/lib/health-data-standards/import/bulk_record_importer.rb
@@ -36,6 +36,7 @@ module HealthDataStandards
             begin
               BulkRecordImporter.import(xml)
             rescue Exception => e
+              puts e
               failed_dir = File.join(file.dirname, 'failed_imports')
               unless(Dir.exists?(failed_dir))
                 Dir.mkdir(failed_dir)
@@ -80,7 +81,7 @@ module HealthDataStandards
         record.provider_performances = providers
         providers.each do |prov| 
           prov.provider.ancestors.each do |ancestor|
-            record.provider_performaces.push(ProviderPerformance.new(start_date: prov.start_date, end_date: prov.end_date, provider: ancestor))  
+            record.provider_performances.push(ProviderPerformance.new(start_date: prov.start_date, end_date: prov.end_date, provider: ancestor))  
           end
         end
         record.save

--- a/templates/cat1/_providers.cat1.erb
+++ b/templates/cat1/_providers.cat1.erb
@@ -39,7 +39,7 @@
         <assignedEntity>
           <% pp.provider.cda_identifiers.each do |cda_id| -%>
             <% unless cda_id.root.eql? '2.16.840.1.113883.4.2' -%>
-          <id root="<%= cda_id.root %>" extension="<%= cda_id.root %>" /> 
+          <id root="<%= cda_id.root %>" extension="<%= cda_id.extension %>" /> 
             <% end -%>
           <% end -%>
           <representedOrganization>


### PR DESCRIPTION
In the Cat I provider template, we were putting the root in the
extension attribute for the provider id

The bulk record importer had a simple typo in a method call
