### PR TITLE
Set value for nil type when loading new MAT export measures

### DIFF
--- a/lib/hqmf-parser/1.0/expression.rb
+++ b/lib/hqmf-parser/1.0/expression.rb
@@ -17,6 +17,8 @@ module HQMF1
         @value = Value.new(@entry.xpath('./*/cda:value'))
       when 'ANYNonNull'
         @value = HQMF::AnyValue.new
+      when nil
+        @value = HQMF::AnyValue.new
       else
         raise "Unknown expression value type #{type}"
       end


### PR DESCRIPTION
- resolves <code>Error Parsing Measure Logic: Unknown expression value type</code> and subsequent failed load for CMS032_PostMAT_Cycle1.zip
