### PR TITLE
Fix patient descriptions to 'definition, status'

### DIFF
--- a/lib/health-data-standards/export/helper/html_view_helper.rb
+++ b/lib/health-data-standards/export/helper/html_view_helper.rb
@@ -19,6 +19,20 @@ module HealthDataStandards
             status
           end
         end
+
+        def decode_hqmf_description(description, oid)
+          if oid
+            definition = HealthDataStandards::Util::HQMFTemplateHelper.definition_for_template_id(oid)['definition']
+            status = HealthDataStandards::Util::HQMFTemplateHelper.definition_for_template_id(oid)['status']
+            unless status.blank?
+              "#{definition.titleize}, #{status.titleize}".to_sym  
+            else
+              "#{definition.titleize}".to_sym
+            end
+          else
+            description
+          end
+        end
       end
     end
   end

--- a/templates/html/_entry.html.erb
+++ b/templates/html/_entry.html.erb
@@ -1,6 +1,6 @@
 <tr class="narr_tr">
   
-  <td><%if entry.negationInd %><b>Not Done: </b><% end %><%= entry.description %></td>
+  <td><%if entry.negationInd %><b>Not Done: </b><% end %><%= decode_hqmf_description(entry.description, entry.oid) %></td>
   <td>
     <% entry.codes.each do |set, codes| %>
       <% entry_key = "#{entry.id}_#{by_encounter}" %>

--- a/templates/html/show.html.erb
+++ b/templates/html/show.html.erb
@@ -130,9 +130,11 @@
         codes.style.display = 'none';
       }
     </script>
+    <% if measures.length==0 %>
     <div>
       <h3><a href="#" onclick="toggle('table_by_encounter');" id="toggle_button">View By Encounter</a></h3>
     </div>
+    <% end %>
     <%== render :partial => 'entries_by_section', :locals => {patient: patient, code_map: code_map, measures: measures} %>
     <% if measures.length==0 %>
     <%== render :partial => 'entries_by_encounter', :locals => {patient: patient, code_map: code_map, measures: measures} %>


### PR DESCRIPTION
- sets description for html export output to <code>Description, Status</code>, if possible; if not, it will use the default description value on the entry
- only render <code>View By Encounter</code> link if we render <code>entries_by_encounter</code>
