### PR TITLE
Support category 3 files export for measures with multiple populations

### DIFF
--- a/lib/health-data-standards/export/cat_3.rb
+++ b/lib/health-data-standards/export/cat_3.rb
@@ -12,7 +12,7 @@ module HealthDataStandards
       def export(measures, header, effective_date, start_date, end_date, filter=nil,test_id=nil)
         results = {}
         measures.each do |measure|
-          results[measure['hqmf_id']] = HealthDataStandards::CQM::QueryCache.aggregate_measure(measure['hqmf_id'], effective_date, filter, test_id)
+          results["#{measure['hqmf_id']}.#{measure['sub_id']}"] = HealthDataStandards::CQM::QueryCache.aggregate_measure(measure['hqmf_id'], measure['sub_id'], effective_date, filter, test_id)
         end
         @rendering_context.render(:template => 'show', 
                                   :locals => {:measures => measures, :start_date => start_date, 

--- a/lib/health-data-standards/models/cqm/query_cache.rb
+++ b/lib/health-data-standards/models/cqm/query_cache.rb
@@ -21,9 +21,9 @@ module HealthDataStandards
       field :OBSERV, type: Float
       field :supplemental_data, type: Hash
 
-      def self.aggregate_measure(measure_id, effective_date, filters=nil, test_id=nil)
+      def self.aggregate_measure(measure_id, sub_id, effective_date, filters=nil, test_id=nil)
         query_hash = {'effective_date' => effective_date, 'measure_id' => measure_id,
-                      'test_id' => test_id}
+                      'sub_id' => sub_id, 'test_id' => test_id}
         if filters
           query_hash.merge!(filters)
         end

--- a/templates/cat3/show.cat3.erb
+++ b/templates/cat3/show.cat3.erb
@@ -116,7 +116,11 @@ Measure Section
                   <id root="<%= measure['hqmf_id'] %>"/>
 
                   <!-- SHOULD This is the title of the eMeasure -->
+                  <% if measure['subtitle'] -%>                  
+                  <text><%= measure['name'] %> (<%= measure['subtitle'] %>)</text>
+                  <% else -%>
                   <text><%= measure['name'] %></text>
+                  <% end %>
                   <!-- SHOULD: setId is the eMeasure version neutral id  -->
                   <setId root="<%= measure['hqmf_set_id'] %>"/>
                   <!-- This is the sequential eMeasure Version number -->
@@ -124,7 +128,7 @@ Measure Section
                 </externalDocument>
               </reference>
 
-              <% result = results[measure['hqmf_id']]
+              <% result = results["#{measure['hqmf_id']}.#{measure['sub_id']}"]
                  unless result.is_cv?
                   result.population_groups.each do |pg|
               -%>

--- a/test/unit/models/cqm/query_cache_test.rb
+++ b/test/unit/models/cqm/query_cache_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class QueryCacheTest < MiniTest::Unit::TestCase
   def test_aggregate_measure
     collection_fixtures('query_cache')
-    aggregate_count = HealthDataStandards::CQM::QueryCache.aggregate_measure("8A4D92B2-397A-48D2-0139-C648B33D5582" ,1356998340)
+    aggregate_count = HealthDataStandards::CQM::QueryCache.aggregate_measure("8A4D92B2-397A-48D2-0139-C648B33D5582", nil, 1356998340)
     ipp_pop = aggregate_count.populations.find{|p| p.type == 'IPP'}
     assert_equal 3, ipp_pop.value
     assert_equal "155518F5-8B70-49AB-A3CB-E53037D5442D", ipp_pop.id


### PR DESCRIPTION
Per our testing we found that when exporting measure with multiple populations in a single QRDA Category 3 file, it duplicates results of a single population and calculates them wrong.

Following code changes resolve this issue for us.
