### PR TITLE
scoping cat1 import xpath statements to the patient data section context...

### DIFF
--- a/lib/health-data-standards/import/cat1/diagnosis_active_importer.rb
+++ b/lib/health-data-standards/import/cat1/diagnosis_active_importer.rb
@@ -4,7 +4,7 @@ module HealthDataStandards
       class DiagnosisActiveImporter < CDA::ConditionImporter
 
         def initialize
-          super(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.11']"))
+          super(CDA::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.11']"))
           @status_xpath = nil # We'll hardcode this to active in create entry because this is from the 
                               # diagnosis active template
           @severity_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.22.4.8']/cda:value"                    

--- a/lib/health-data-standards/import/cat1/diagnosis_inactive_importer.rb
+++ b/lib/health-data-standards/import/cat1/diagnosis_inactive_importer.rb
@@ -4,7 +4,7 @@ module HealthDataStandards
       class DiagnosisInactiveImporter < CDA::ConditionImporter
 
         def initialize
-          super(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.13']"))
+          super(CDA::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.13']"))
           @status_xpath = nil # We'll hardcode this to inactive in create entry because this is from the 
                               # diagnosis active template
         end

--- a/lib/health-data-standards/import/cat1/diagnostic_study_order_importer.rb
+++ b/lib/health-data-standards/import/cat1/diagnostic_study_order_importer.rb
@@ -2,7 +2,7 @@ module HealthDataStandards
   module Import
     module Cat1
       class DiagnosticStudyOrderImporter < CDA::SectionImporter
-        def initialize(entry_finder=CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.17']"))
+        def initialize(entry_finder=CDA::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.17']"))
           super(entry_finder)
           @entry_class = Procedure
         end

--- a/lib/health-data-standards/import/cat1/ecog_status_importer.rb
+++ b/lib/health-data-standards/import/cat1/ecog_status_importer.rb
@@ -2,7 +2,7 @@ module HealthDataStandards
   module Import
     module Cat1
       class EcogStatusImporter < CDA::SectionImporter
-        def initialize(entry_finder=CDA::EntryFinder.new("//cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.103']"))
+        def initialize(entry_finder=CDA::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.103']"))
           super(entry_finder)
           @code_xpath = './cda:value'
         end

--- a/lib/health-data-standards/import/cat1/encounter_order_importer.rb
+++ b/lib/health-data-standards/import/cat1/encounter_order_importer.rb
@@ -2,7 +2,7 @@ module HealthDataStandards
   module Import
     module Cat1
       class EncounterOrderImporter < CDA::EncounterImporter
-        def initialize(entry_finder=CDA::EntryFinder.new("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.22']"))
+        def initialize(entry_finder=CDA::EntryFinder.new("./cda:entry/cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.22']"))
           super(entry_finder)
         end
 

--- a/lib/health-data-standards/import/cat1/encounter_performed_importer.rb
+++ b/lib/health-data-standards/import/cat1/encounter_performed_importer.rb
@@ -2,7 +2,7 @@ module HealthDataStandards
   module Import
     module Cat1
       class EncounterPerformedImporter < CDA::EncounterImporter
-        def initialize(entry_finder=CDA::EntryFinder.new("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']"))
+        def initialize(entry_finder=CDA::EntryFinder.new("./cda:entry/cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']"))
           super(entry_finder)
           @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation"
         end

--- a/lib/health-data-standards/import/cat1/gestational_age_importer.rb
+++ b/lib/health-data-standards/import/cat1/gestational_age_importer.rb
@@ -4,7 +4,7 @@ module HealthDataStandards
       class GestationalAgeImporter < CDA::SectionImporter
 
         def initialize
-          super(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.101']"))
+          super(CDA::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.101']"))
 
         end
 

--- a/lib/health-data-standards/import/cat1/insurance_provider_importer.rb
+++ b/lib/health-data-standards/import/cat1/insurance_provider_importer.rb
@@ -4,7 +4,7 @@ module HealthDataStandards
       class InsuranceProviderImporter < CDA::SectionImporter
       
         def initialize
-          super(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.55']"))
+          super(CDA::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.55']"))
           @check_for_usable = false # needs to be this way becase InsuranceProvider does not respond
                                     # to usable?
         end

--- a/lib/health-data-standards/import/cat1/lab_order_importer.rb
+++ b/lib/health-data-standards/import/cat1/lab_order_importer.rb
@@ -2,7 +2,7 @@ module HealthDataStandards
   module Import
     module Cat1
       class LabOrderImporter < CDA::SectionImporter
-        def initialize(entry_finder=CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.37']"))
+        def initialize(entry_finder=CDA::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.37']"))
           super(entry_finder)
           @entry_class = LabResult
         end

--- a/lib/health-data-standards/import/cat1/lab_result_importer.rb
+++ b/lib/health-data-standards/import/cat1/lab_result_importer.rb
@@ -2,7 +2,7 @@ module HealthDataStandards
   module Import
     module Cat1
       class LabResultImporter < CDA::SectionImporter
-        def initialize(entry_finder=CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.40']"))
+        def initialize(entry_finder=CDA::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.40']"))
           super(entry_finder)
           @entry_class = LabResult
         end

--- a/lib/health-data-standards/import/cat1/medication_active_importer.rb
+++ b/lib/health-data-standards/import/cat1/medication_active_importer.rb
@@ -4,7 +4,7 @@ module HealthDataStandards
       class MedicationActiveImporter < CDA::MedicationImporter
 
         def initialize
-          super(CDA::EntryFinder.new("//cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.41']"))
+          super(CDA::EntryFinder.new("./cda:entry/cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.41']"))
         end
 
         def create_entry(entry_element, nrh = CDA::NarrativeReferenceHandler.new)

--- a/lib/health-data-standards/import/cat1/medication_dispensed_importer.rb
+++ b/lib/health-data-standards/import/cat1/medication_dispensed_importer.rb
@@ -2,7 +2,7 @@ module HealthDataStandards
   module Import
     module Cat1
       class MedicationDispensedImporter < CDA::SectionImporter
-        def initialize(entry_finder=CDA::EntryFinder.new("//cda:supply[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.45']"))
+        def initialize(entry_finder=CDA::EntryFinder.new("./cda:entry/cda:supply[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.45']"))
           super(entry_finder)
           @code_xpath = "./cda:product/cda:manufacturedProduct/cda:manufacturedMaterial/cda:code"
           @entry_class = Medication

--- a/lib/health-data-standards/import/cat1/patient_importer.rb
+++ b/lib/health-data-standards/import/cat1/patient_importer.rb
@@ -13,53 +13,53 @@ module HealthDataStandards
         def initialize
           # This differs from other HDS patient importers in that sections can have multiple importers
           @section_importers = {}
-          @section_importers[:care_goals] = [generate_importer(CDA::SectionImporter, "//cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.1']", '2.16.840.1.113883.3.560.1.9')] #care goal
+          @section_importers[:care_goals] = [generate_importer(CDA::SectionImporter, "./cda:entry/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.1']", '2.16.840.1.113883.3.560.1.9')] #care goal
           
           @section_importers[:conditions] = [generate_importer(GestationalAgeImporter, nil, '2.16.840.1.113883.3.560.1.1001'),
                                              generate_importer(EcogStatusImporter, nil, '2.16.840.1.113883.3.560.1.1001'),
                                              generate_importer(SymptomActiveImporter, nil, '2.16.840.1.113883.3.560.1.69', 'active'),
                                              generate_importer(DiagnosisActiveImporter, nil, '2.16.840.1.113883.3.560.1.2', 'active'),
-                                             generate_importer(CDA::ConditionImporter, "//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.54']", '2.16.840.1.113883.3.560.1.404'), # patient characteristic age
-                                             generate_importer(CDA::ConditionImporter, "//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.14']", '2.16.840.1.113883.3.560.1.24', 'resolved'), #diagnosis resolved
+                                             generate_importer(CDA::ConditionImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.54']", '2.16.840.1.113883.3.560.1.404'), # patient characteristic age
+                                             generate_importer(CDA::ConditionImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.14']", '2.16.840.1.113883.3.560.1.24', 'resolved'), #diagnosis resolved
                                              generate_importer(DiagnosisInactiveImporter, nil, '2.16.840.1.113883.3.560.1.23', 'inactive')] #diagnosis inactive
   
           
-          @section_importers[:medications] = [generate_importer(CDA::MedicationImporter, "//cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.105']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.41']", '2.16.840.1.113883.3.560.1.199', 'discharge'), #discharge medication active
+          @section_importers[:medications] = [generate_importer(CDA::MedicationImporter, "./cda:entry/cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.105']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.41']", '2.16.840.1.113883.3.560.1.199', 'discharge'), #discharge medication active
                                               generate_importer(MedicationActiveImporter, nil, '2.16.840.1.113883.3.560.1.13', 'active'), #medication active
-                                              generate_importer(CDA::MedicationImporter, "//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.42']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.22.4.16']", '2.16.840.1.113883.3.560.1.14', 'administered'), #medication administered
-                                              generate_importer(CDA::MedicationImporter, "//cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.47']", '2.16.840.1.113883.3.560.1.17', 'ordered'), #medication order TODO: ADD NEGATON REASON HANDLING SOMEHOW
+                                              generate_importer(CDA::MedicationImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.42']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.22.4.16']", '2.16.840.1.113883.3.560.1.14', 'administered'), #medication administered
+                                              generate_importer(CDA::MedicationImporter, "./cda:entry/cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.47']", '2.16.840.1.113883.3.560.1.17', 'ordered'), #medication order TODO: ADD NEGATON REASON HANDLING SOMEHOW
                                               generate_importer(MedicationDispensedImporter, nil, '2.16.840.1.113883.3.560.1.8', 'dispensed')]
 
-          @section_importers[:procedures] = [generate_importer(CDA::ProcedureImporter, "//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.59']", '2.16.840.1.113883.3.560.1.57', 'performed'), #physical exam performed
-                                             generate_importer(CDA::ProcedureImporter, "//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.3']", '2.16.840.1.113883.3.560.1.131'), #comm from provider to patient
-                                             generate_importer(CDA::ProcedureImporter, "//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.31']", '2.16.840.1.113883.3.560.1.45', 'ordered'), #intervention ordered
-                                             generate_importer(CDA::ProcedureImporter, "//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.32']", '2.16.840.1.113883.3.560.1.46', 'performed'), #intervention performed
-                                             generate_importer(CDA::ProcedureImporter, "//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']", '2.16.840.1.113883.3.560.1.47'), #intervention result
-                                             generate_importer(CDA::ProcedureImporter, "//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.4']", '2.16.840.1.113883.3.560.1.129'), #comm from provider to provider
-                                             generate_importer(CDA::ProcedureImporter, "//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.2']", '2.16.840.1.113883.3.560.1.30'), #comm from patient to provider
+          @section_importers[:procedures] = [generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.59']", '2.16.840.1.113883.3.560.1.57', 'performed'), #physical exam performed
+                                             generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.3']", '2.16.840.1.113883.3.560.1.131'), #comm from provider to patient
+                                             generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.31']", '2.16.840.1.113883.3.560.1.45', 'ordered'), #intervention ordered
+                                             generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.32']", '2.16.840.1.113883.3.560.1.46', 'performed'), #intervention performed
+                                             generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']", '2.16.840.1.113883.3.560.1.47'), #intervention result
+                                             generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.4']", '2.16.840.1.113883.3.560.1.129'), #comm from provider to provider
+                                             generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.2']", '2.16.840.1.113883.3.560.1.30'), #comm from patient to provider
                                              generate_importer(ProcedureOrderImporter, nil, '2.16.840.1.113883.3.560.1.62', 'ordered'),
-                                             generate_importer(ProcedurePerformedImporter, "//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.64']", '2.16.840.1.113883.3.560.1.6'),
-                                             generate_importer(CDA::ProcedureImporter, "//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.66']", '2.16.840.1.113883.3.560.1.63'),
-                                             generate_importer(CDA::ProcedureImporter, "//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.69']", '2.16.840.1.113883.3.560.1.21'), #risk category assessment
-                                             generate_importer(CDA::ProcedureImporter, "//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.18']", '2.16.840.1.113883.3.560.1.103', 'performed'), #diagnostic study performed
+                                             generate_importer(ProcedurePerformedImporter, "./cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.64']", '2.16.840.1.113883.3.560.1.6'),
+                                             generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.66']", '2.16.840.1.113883.3.560.1.63'),
+                                             generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.69']", '2.16.840.1.113883.3.560.1.21'), #risk category assessment
+                                             generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.18']", '2.16.840.1.113883.3.560.1.103', 'performed'), #diagnostic study performed
                                              generate_importer(DiagnosticStudyOrderImporter, nil, '2.16.840.1.113883.3.560.1.40', 'ordered')]
 
           @section_importers[:allergies] = [generate_importer(ProcedureIntoleranceImporter, nil, '2.16.840.1.113883.3.560.1.61'),
-                                            generate_importer(CDA::AllergyImporter, "//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.46']", '2.16.840.1.113883.3.560.1.67'), #medication intolerance
-                                            generate_importer(CDA::AllergyImporter, "//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.43']", '2.16.840.1.113883.3.560.1.7'), #medication adverse effect
-                                            generate_importer(CDA::AllergyImporter, "//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.44']", '2.16.840.1.113883.3.560.1.1')] #medication allergy
+                                            generate_importer(CDA::AllergyImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.46']", '2.16.840.1.113883.3.560.1.67'), #medication intolerance
+                                            generate_importer(CDA::AllergyImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.43']", '2.16.840.1.113883.3.560.1.7'), #medication adverse effect
+                                            generate_importer(CDA::AllergyImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.44']", '2.16.840.1.113883.3.560.1.1')] #medication allergy
 
-          @section_importers[:medical_equipment] = [generate_importer(CDA::MedicalEquipmentImporter, "//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.7']", '2.16.840.1.113883.3.560.1.110', 'applied')]
+          @section_importers[:medical_equipment] = [generate_importer(CDA::MedicalEquipmentImporter, "./cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.7']", '2.16.840.1.113883.3.560.1.110', 'applied')]
 
           @section_importers[:results] = [generate_importer(LabOrderImporter, nil, '2.16.840.1.113883.3.560.1.50', 'ordered'), #lab ordered
-                                          generate_importer(CDA::ResultImporter, "//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.38']", '2.16.840.1.113883.3.560.1.5', 'performed'), #lab performed
-                                          generate_importer(CDA::ResultImporter, "//cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']", '2.16.840.1.113883.3.560.1.47'), #intervention result
-                                          generate_importer(CDA::ResultImporter, "//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.57']", '2.16.840.1.113883.3.560.1.18'), #physical exam finding
-                                          generate_importer(CDA::ResultImporter, "//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.28']", '2.16.840.1.113883.3.560.1.88'), #functional status result    
-                                          generate_importer(CDA::ResultImporter, "//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.20']", '2.16.840.1.113883.3.560.1.111'), #diagnostic study result not done
+                                          generate_importer(CDA::ResultImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.38']", '2.16.840.1.113883.3.560.1.5', 'performed'), #lab performed
+                                          generate_importer(CDA::ResultImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']", '2.16.840.1.113883.3.560.1.47'), #intervention result
+                                          generate_importer(CDA::ResultImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.57']", '2.16.840.1.113883.3.560.1.18'), #physical exam finding
+                                          generate_importer(CDA::ResultImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.28']", '2.16.840.1.113883.3.560.1.88'), #functional status result    
+                                          generate_importer(CDA::ResultImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.20']", '2.16.840.1.113883.3.560.1.111'), #diagnostic study result not done
                                           generate_importer(LabResultImporter, nil, '2.16.840.1.113883.3.560.1.12')] #lab result
 
-          @section_importers[:encounters] = [generate_importer(EncounterPerformedImporter, "//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']", '2.16.840.1.113883.3.560.1.79', 'performed'), #encounter performed
+          @section_importers[:encounters] = [generate_importer(EncounterPerformedImporter, "./cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']", '2.16.840.1.113883.3.560.1.79', 'performed'), #encounter performed
                                              generate_importer(EncounterOrderImporter, nil, '2.16.840.1.113883.3.560.1.83', 'ordered')]
 
           @section_importers[:social_history] = [generate_importer(TobaccoUseImporter, nil, '2.16.840.1.113883.3.560.1.1001', 'completed')]
@@ -79,22 +79,24 @@ module HealthDataStandards
         end
 
         def import_sections(record, doc)
+
+          context = doc.xpath("/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section[cda:templateId/@root = '2.16.840.1.113883.10.20.24.2.1']")
           nrh = CDA::NarrativeReferenceHandler.new
           nrh.build_id_map(doc)
           @section_importers.each do |section, entry_packages|
             entry_packages.each do |entry_package|
-              record.send(section) << entry_package.package_entries(doc, nrh)
+              record.send(section) << entry_package.package_entries(context, nrh)
             end
           end
         end
 
         def get_clinical_trial_participant(record, doc)
-          entry_elements = doc.xpath("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.51']")
+          entry_elements = doc.xpath("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.51']")
           record.clinicalTrialParticipant = true unless entry_elements.blank?
         end
 
         def get_patient_expired(record, doc)
-          entry_elements = doc.xpath("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.54']")
+          entry_elements = doc.xpath("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.54']")
           record.expired = true unless entry_elements.empty?
         end
 

--- a/lib/health-data-standards/import/cat1/procedure_intolerance_importer.rb
+++ b/lib/health-data-standards/import/cat1/procedure_intolerance_importer.rb
@@ -4,7 +4,7 @@ module HealthDataStandards
       class ProcedureIntoleranceImporter < CDA::SectionImporter
 
         def initialize
-          super(CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.62']/cda:entryRelationship/cda:procedure[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.64']"))
+          super(CDA::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.62']/cda:entryRelationship/cda:procedure[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.64']"))
           @entry_class = Allergy
         end
       end

--- a/lib/health-data-standards/import/cat1/procedure_order_importer.rb
+++ b/lib/health-data-standards/import/cat1/procedure_order_importer.rb
@@ -2,7 +2,7 @@ module HealthDataStandards
   module Import
     module Cat1
       class ProcedureOrderImporter < CDA::SectionImporter
-        def initialize(entry_finder=CDA::EntryFinder.new("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.63']"))
+        def initialize(entry_finder=CDA::EntryFinder.new("./cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.63']"))
           super(entry_finder)
           @entry_class = Procedure
         end

--- a/lib/health-data-standards/import/cat1/procedure_performed_importer.rb
+++ b/lib/health-data-standards/import/cat1/procedure_performed_importer.rb
@@ -2,7 +2,7 @@ module HealthDataStandards
   module Import
     module Cat1
       class ProcedurePerformedImporter < CDA::SectionImporter
-        def initialize(entry_finder=CDA::EntryFinder.new("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.64']"))
+        def initialize(entry_finder=CDA::EntryFinder.new("./cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.64']"))
           super(entry_finder)
           @entry_class = Procedure
           @ordinality_xpath = "./cda:priorityCode"

--- a/lib/health-data-standards/import/cat1/symptom_active_importer.rb
+++ b/lib/health-data-standards/import/cat1/symptom_active_importer.rb
@@ -2,7 +2,7 @@ module HealthDataStandards
   module Import
     module Cat1
       class SymptomActiveImporter < CDA::SectionImporter
-        def initialize(entry_finder=CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.76']"))
+        def initialize(entry_finder=CDA::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.76']"))
           super(entry_finder)
           @code_xpath = './cda:value'
         end

--- a/lib/health-data-standards/import/cat1/tobacco_use_importer.rb
+++ b/lib/health-data-standards/import/cat1/tobacco_use_importer.rb
@@ -2,7 +2,7 @@ module HealthDataStandards
   module Import
     module Cat1
       class TobaccoUseImporter < CDA::SectionImporter
-        def initialize(entry_finder=CDA::EntryFinder.new("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.22.4.85']"))
+        def initialize(entry_finder=CDA::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.22.4.85']"))
           super(entry_finder)
           @entry_class = Entry
         end

--- a/test/fixtures/cat1_fragments/care_goal_fragment.xml
+++ b/test/fixtures/cat1_fragments/care_goal_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="GOL">
               <!-- 2.16.840.1.113883.10.20.22.4.44 Plan of Care Activity Observation -->

--- a/test/fixtures/cat1_fragments/clinical_trial_participant_fragment.xml
+++ b/test/fixtures/cat1_fragments/clinical_trial_participant_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <!-- Clinical Trial Participant -->
             <observation classCode="OBS" moodCode="EVN">

--- a/test/fixtures/cat1_fragments/comm_patient_to_provider_fragment.xml
+++ b/test/fixtures/cat1_fragments/comm_patient_to_provider_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>  
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <act classCode="ACT" moodCode="EVN">
               <!-- Communication from patient to provider -->

--- a/test/fixtures/cat1_fragments/comm_prov_to_patient_fragment.xml
+++ b/test/fixtures/cat1_fragments/comm_prov_to_patient_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <act classCode="ACT" moodCode="EVN">
               <templateId root="2.16.840.1.113883.10.20.24.3.3"/>

--- a/test/fixtures/cat1_fragments/comm_provider_to_provider_fragment.xml
+++ b/test/fixtures/cat1_fragments/comm_provider_to_provider_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <act classCode="ACT" moodCode="EVN" >
               <!-- Communication from provider to provider -->

--- a/test/fixtures/cat1_fragments/condition_expired_fragment.xml
+++ b/test/fixtures/cat1_fragments/condition_expired_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <!-- Patient characteristic expired -->
             <observation classCode="OBS" moodCode="EVN">

--- a/test/fixtures/cat1_fragments/device_applied_fragment.xml
+++ b/test/fixtures/cat1_fragments/device_applied_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>  
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <procedure classCode="PROC" moodCode="EVN" >
               <!-- Procedure Activity Procedure -->

--- a/test/fixtures/cat1_fragments/diagnosis_active_fragment.xml
+++ b/test/fixtures/cat1_fragments/diagnosis_active_fragment.xml
@@ -4,6 +4,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN">
               <!--  Problem observation template -->

--- a/test/fixtures/cat1_fragments/diagnosis_inactive_fragment.xml
+++ b/test/fixtures/cat1_fragments/diagnosis_inactive_fragment.xml
@@ -4,6 +4,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN">
             <!--  Problem observation template -->

--- a/test/fixtures/cat1_fragments/diagnosis_resolved_fragment.xml
+++ b/test/fixtures/cat1_fragments/diagnosis_resolved_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN">
               <!--  Problem observation template -->

--- a/test/fixtures/cat1_fragments/diagnostic_study_order_fragment.xml
+++ b/test/fixtures/cat1_fragments/diagnostic_study_order_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="RQO">
             <!-- Consolidated Plan of Care Activity Observation 

--- a/test/fixtures/cat1_fragments/diagnostic_study_performed_fragment.xml
+++ b/test/fixtures/cat1_fragments/diagnostic_study_performed_fragment.xml
@@ -4,6 +4,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN" >
               <!-- Consolidated Procedure Activity Observation templateId 

--- a/test/fixtures/cat1_fragments/diagnostic_study_result_fragment.xml
+++ b/test/fixtures/cat1_fragments/diagnostic_study_result_fragment.xml
@@ -4,6 +4,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN" negationInd="true">
               <!-- Consolidated Result Observation templateId (Implied Template) -->

--- a/test/fixtures/cat1_fragments/discharge_medication_fragment.xml
+++ b/test/fixtures/cat1_fragments/discharge_medication_fragment.xml
@@ -4,6 +4,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <act classCode="ACT" moodCode="EVN">
               <!-- Discharge Medication Entry -->

--- a/test/fixtures/cat1_fragments/ecog_fragment.xml
+++ b/test/fixtures/cat1_fragments/ecog_fragment.xml
@@ -4,6 +4,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN">
               <templateId root="2.16.840.1.113883.10.20.24.3.103"/>

--- a/test/fixtures/cat1_fragments/encounter_order_fragment.xml
+++ b/test/fixtures/cat1_fragments/encounter_order_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <encounter classCode="ENC" moodCode="RQO">
               <!--  Plan of Care Activity Encounter template -->

--- a/test/fixtures/cat1_fragments/encounter_performed_fragment.xml
+++ b/test/fixtures/cat1_fragments/encounter_performed_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <encounter classCode="ENC" moodCode="EVN">
               <!--  Encounter activities template -->

--- a/test/fixtures/cat1_fragments/functional_status_result_fragment.xml
+++ b/test/fixtures/cat1_fragments/functional_status_result_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN">
               <!-- Functional Status Result Observation (consolidation) template -->

--- a/test/fixtures/cat1_fragments/gestational_age_fragment.xml
+++ b/test/fixtures/cat1_fragments/gestational_age_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN">
               <templateId root="2.16.840.1.113883.10.20.24.3.101"/>

--- a/test/fixtures/cat1_fragments/insurance_provider_fragment.xml
+++ b/test/fixtures/cat1_fragments/insurance_provider_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <!-- Patient Characteristic Payer -->
             <observation classCode="OBS" moodCode="EVN">

--- a/test/fixtures/cat1_fragments/intervention_order_fragment.xml
+++ b/test/fixtures/cat1_fragments/intervention_order_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <act classCode="ACT" moodCode="RQO">
               <!-- Plan of Care Activity Act template -->

--- a/test/fixtures/cat1_fragments/intervention_performed_fragment.xml
+++ b/test/fixtures/cat1_fragments/intervention_performed_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <act classCode="ACT" moodCode="EVN" >
               <!-- Consolidation CDA: Procedure Activity Act template -->

--- a/test/fixtures/cat1_fragments/intervention_result_fragment.xml
+++ b/test/fixtures/cat1_fragments/intervention_result_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <act classCode="ACT" moodCode="EVN">
               <!-- Consolidation CDA: Procedure Activity Act template -->

--- a/test/fixtures/cat1_fragments/lab_order_fragment.xml
+++ b/test/fixtures/cat1_fragments/lab_order_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="RQO">
               <!-- Consolidation Plan of Care Activity Observation -->

--- a/test/fixtures/cat1_fragments/lab_performed_fragment.xml
+++ b/test/fixtures/cat1_fragments/lab_performed_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN" >
               <!-- Lab test performed -->

--- a/test/fixtures/cat1_fragments/lab_result_fragment.xml
+++ b/test/fixtures/cat1_fragments/lab_result_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <!--Laboratory test, result -->
             <observation classCode="OBS" moodCode="EVN">

--- a/test/fixtures/cat1_fragments/medication_active_fragment.xml
+++ b/test/fixtures/cat1_fragments/medication_active_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <substanceAdministration classCode="SBADM" moodCode="EVN" >
               <!-- Medication Activity (consolidation) template -->

--- a/test/fixtures/cat1_fragments/medication_admin_fragment.xml
+++ b/test/fixtures/cat1_fragments/medication_admin_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <act classCode="ACT" moodCode="EVN" >
               <!-- Medication, Administered template -->

--- a/test/fixtures/cat1_fragments/medication_adverse_fragment.xml
+++ b/test/fixtures/cat1_fragments/medication_adverse_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN">
               <!-- consolidation CDA Allergy observation template -->

--- a/test/fixtures/cat1_fragments/medication_allergy_fragment.xml
+++ b/test/fixtures/cat1_fragments/medication_allergy_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN">
               <!-- consolidation CDA Allergy observation template -->

--- a/test/fixtures/cat1_fragments/medication_dispensed_fragment.xml
+++ b/test/fixtures/cat1_fragments/medication_dispensed_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <!--Medication dispensed -->
             <supply classCode="SPLY" moodCode="EVN">

--- a/test/fixtures/cat1_fragments/medication_intolerance_fragment.xml
+++ b/test/fixtures/cat1_fragments/medication_intolerance_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN">
               <!-- consolidation CDA Allergy Observation template -->

--- a/test/fixtures/cat1_fragments/medication_order_fragment.xml
+++ b/test/fixtures/cat1_fragments/medication_order_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <!--Medication Order -->
             <substanceAdministration classCode="SBADM" moodCode="RQO" negationInd="true">

--- a/test/fixtures/cat1_fragments/physical_exam_finding_fragment.xml
+++ b/test/fixtures/cat1_fragments/physical_exam_finding_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <!-- Physical Exam Finding -->
             <observation classCode="OBS" moodCode="EVN">

--- a/test/fixtures/cat1_fragments/physical_exam_performed_fragment.xml
+++ b/test/fixtures/cat1_fragments/physical_exam_performed_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN" negationInd="true">
               <!-- Procedure Activity Procedure (Consolidation) template -->

--- a/test/fixtures/cat1_fragments/procedure_intolerance_fragment.xml
+++ b/test/fixtures/cat1_fragments/procedure_intolerance_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN">
               <templateId root="2.16.840.1.113883.10.20.24.3.62"/>

--- a/test/fixtures/cat1_fragments/procedure_order_fragment.xml
+++ b/test/fixtures/cat1_fragments/procedure_order_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <procedure classCode="PROC" moodCode="RQO" >
             <!-- Consolidated Plan of Care Activity Procedure TemplateId (Implied Template) -->

--- a/test/fixtures/cat1_fragments/procedure_performed_fragment.xml
+++ b/test/fixtures/cat1_fragments/procedure_performed_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <procedure classCode="PROC" moodCode="EVN" negationInd="true">
               <!--  Procedure performed template -->

--- a/test/fixtures/cat1_fragments/procedure_result_fragment.xml
+++ b/test/fixtures/cat1_fragments/procedure_result_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <procedure classCode="PROC" moodCode="EVN">
               <!-- Consolidated Procedure Activity Procedure TemplateId 

--- a/test/fixtures/cat1_fragments/risk_category_assessment_fragment.xml
+++ b/test/fixtures/cat1_fragments/risk_category_assessment_fragment.xml
@@ -4,7 +4,8 @@
   <component>
     <structuredBody>
       <component>
-        <section>   
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN" >
               <!-- Consolidation Assessment Scale Observation templateId -->

--- a/test/fixtures/cat1_fragments/symptom_active_fragment.xml
+++ b/test/fixtures/cat1_fragments/symptom_active_fragment.xml
@@ -4,7 +4,8 @@
   <component>
     <structuredBody>
       <component>
-        <section>  
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN">
               <!--  Problem observation template -->

--- a/test/fixtures/cat1_fragments/tobacco_use_fragment.xml
+++ b/test/fixtures/cat1_fragments/tobacco_use_fragment.xml
@@ -5,6 +5,7 @@
     <structuredBody>
       <component>
         <section>
+          <templateId root="2.16.840.1.113883.10.20.24.2.1"/>
           <entry>
             <observation classCode="OBS" moodCode="EVN">
               <templateId root="2.16.840.1.113883.10.20.22.4.85"/>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -105,6 +105,10 @@ def collection_fixtures(collection, *id_attributes)
   end
 end
 
+def cat1_patient_data_section(doc)
+  doc.xpath("/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section[cda:templateId/@root = '2.16.840.1.113883.10.20.24.2.1']")
+end
+
 collection_fixtures('records', '_id')
 collection_fixtures('health_data_standards_svs_value_sets', '_id')
 collection_fixtures('measures')

--- a/test/unit/import/cat1/diagnosis_active_importer_test.rb
+++ b/test/unit/import/cat1/diagnosis_active_importer_test.rb
@@ -7,7 +7,7 @@ class DiagnosisActiveImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     diag = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::DiagnosisActiveImporter.new, '2.16.840.1.113883.3.560.1.2', 'active')
-    diagnoses = diag.package_entries(doc, nrh)
+    diagnoses = diag.package_entries(cat1_patient_data_section(doc), nrh)
     diagnosis = diagnoses[0]
     severity = {"SNOMED-CT" =>["55561003"]}
     assert diagnosis.codes['ICD-9-CM'].include?("999.34")

--- a/test/unit/import/cat1/diagnosis_inactive_importer_test.rb
+++ b/test/unit/import/cat1/diagnosis_inactive_importer_test.rb
@@ -7,7 +7,7 @@ class DiagnosisInactiveImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     diag = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::DiagnosisInactiveImporter.new, '2.16.840.1.113883.3.560.1.23', 'inactive')
-    diagnoses = diag.package_entries(doc, nrh)
+    diagnoses = diag.package_entries(cat1_patient_data_section(doc), nrh)
     diagnosis = diagnoses[0]
     assert diagnosis.codes['ICD-9-CM'].include?("V02.61")
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('20040816121859')

--- a/test/unit/import/cat1/diagnostic_study_order_test.rb
+++ b/test/unit/import/cat1/diagnostic_study_order_test.rb
@@ -7,7 +7,7 @@ class DiagnosticStudyOrderImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     ord = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::DiagnosticStudyOrderImporter.new, '2.16.840.1.113883.3.560.1.40', 'ordered')
-    orders = ord.package_entries(doc, nrh)
+    orders = ord.package_entries(cat1_patient_data_section(doc), nrh)
     order = orders[0]
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19891215072420')
     assert order.codes['LOINC'].include?("69399-4")

--- a/test/unit/import/cat1/ecog_status_importer_test.rb
+++ b/test/unit/import/cat1/ecog_status_importer_test.rb
@@ -7,7 +7,7 @@ class EcogStatusImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     ecog = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::EcogStatusImporter.new, '2.16.840.1.113883.3.560.1.1001')
-    ecog_statuses = ecog.package_entries(doc, nrh)
+    ecog_statuses = ecog.package_entries(cat1_patient_data_section(doc), nrh)
     ecog_status = ecog_statuses[0]
     assert ecog_status.codes['SNOMED-CT'].include?('423237006')
     expected_timestamp = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('20120619085355')

--- a/test/unit/import/cat1/encounter_order_importer_test.rb
+++ b/test/unit/import/cat1/encounter_order_importer_test.rb
@@ -7,7 +7,7 @@ class EncounterOrderImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     enc = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::EncounterOrderImporter.new, '2.16.840.1.113883.3.560.1.83', 'ordered')
-    encounters = enc.package_entries(doc, nrh)
+    encounters = enc.package_entries(cat1_patient_data_section(doc), nrh)
     encounter = encounters[0]
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('20051226144034')
     assert encounter.codes['SNOMED-CT'].include?("76168009")

--- a/test/unit/import/cat1/encounter_transfer_importer_test.rb
+++ b/test/unit/import/cat1/encounter_transfer_importer_test.rb
@@ -7,7 +7,7 @@ class EncounterTransferImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     enc = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::CDA::EncounterImporter.new(HealthDataStandards::Import::CDA::EntryFinder.new("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']")), '2.16.840.1.113883.3.560.1.79', 'performed')
-    encounters = enc.package_entries(doc, nrh)
+    encounters = enc.package_entries(cat1_patient_data_section(doc), nrh)
     encounter = encounters[0]
     from_time = 20120214
     to_time = 20120214

--- a/test/unit/import/cat1/gestational_age_importer_test.rb
+++ b/test/unit/import/cat1/gestational_age_importer_test.rb
@@ -7,7 +7,7 @@ class GestationalAgeImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     gai = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::GestationalAgeImporter.new, '2.16.840.1.113883.3.560.1.1001')
-		gais = gai.package_entries(doc, nrh)
+		gais = gai.package_entries(cat1_patient_data_section(doc), nrh)
 		gestational_age = gais[0]
 		assert gestational_age.codes['SNOMED-CT'].include?("931004")
   end

--- a/test/unit/import/cat1/insurance_provider_importer_test.rb
+++ b/test/unit/import/cat1/insurance_provider_importer_test.rb
@@ -8,7 +8,7 @@ class InsuranceProviderImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     ipi = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::InsuranceProviderImporter.new, '2.16.840.1.113883.3.560.1.69', 'active')
-    insurance_providers = ipi.package_entries(doc, nrh)
+    insurance_providers = ipi.package_entries(cat1_patient_data_section(doc), nrh)
     assert_equal 1, insurance_providers.size
     assert_equal({ 'SOP' => ['349'] }, insurance_providers.first.codes)
   end

--- a/test/unit/import/cat1/lab_order_importer_test.rb
+++ b/test/unit/import/cat1/lab_order_importer_test.rb
@@ -7,7 +7,7 @@ class LabOrderImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     lo = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::LabOrderImporter.new, '2.16.840.1.113883.3.560.1.50', 'ordered')
-    lab_orders = lo.package_entries(doc, nrh)
+    lab_orders = lo.package_entries(cat1_patient_data_section(doc), nrh)
     lab_order = lab_orders[0]
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19910519162436')
     assert lab_order.codes['SNOMED-CT'].include?('8879006')

--- a/test/unit/import/cat1/lab_result_importer_test.rb
+++ b/test/unit/import/cat1/lab_result_importer_test.rb
@@ -7,7 +7,7 @@ class LabResultImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     lr = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::LabResultImporter.new, '2.16.840.1.113883.3.560.1.12')
-    lab_results = lr.package_entries(doc, nrh)
+    lab_results = lr.package_entries(cat1_patient_data_section(doc), nrh)
     lab_result = lab_results[0]
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19910519162436')
     assert lab_result.codes['LOINC'].include?('11268-0')

--- a/test/unit/import/cat1/medication_active_importer_test.rb
+++ b/test/unit/import/cat1/medication_active_importer_test.rb
@@ -9,7 +9,7 @@ class MedicationActiveImporterTest < MiniTest::Unit::TestCase
     nrh = CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     packager = Cat1::EntryPackage.new(Cat1::MedicationActiveImporter.new, '2.16.840.1.113883.3.560.1.13', 'active')
-    medication = packager.package_entries(doc, nrh).first
+    medication = packager.package_entries(cat1_patient_data_section(doc), nrh).first
     
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19890509170647')
     expected_end = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19890509173724')

--- a/test/unit/import/cat1/medication_dispensed_test.rb
+++ b/test/unit/import/cat1/medication_dispensed_test.rb
@@ -7,7 +7,7 @@ class MedicationDispensedImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     med = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::MedicationDispensedImporter.new, '2.16.840.1.113883.3.560.1.8', 'dispensed')
-    medications = med.package_entries(doc, nrh)
+    medications = med.package_entries(cat1_patient_data_section(doc), nrh)
     medication = medications[0]
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19960119172123')
     expected_end = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19960119221325')

--- a/test/unit/import/cat1/patient_importer_test.rb
+++ b/test/unit/import/cat1/patient_importer_test.rb
@@ -184,13 +184,13 @@ class PatientImporterTest < MiniTest::Unit::TestCase
     dead_patient = Record.new
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/condition_expired_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    HealthDataStandards::Import::Cat1::PatientImporter.instance.get_patient_expired(dead_patient, doc)
+    HealthDataStandards::Import::Cat1::PatientImporter.instance.get_patient_expired(dead_patient, cat1_patient_data_section(doc))
     assert dead_patient.expired
 
     alive_patient = Record.new
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/functional_status_result_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    HealthDataStandards::Import::Cat1::PatientImporter.instance.get_patient_expired(alive_patient, doc)
+    HealthDataStandards::Import::Cat1::PatientImporter.instance.get_patient_expired(alive_patient, cat1_patient_data_section(doc))
     refute alive_patient.expired
   end
 
@@ -208,7 +208,7 @@ class PatientImporterTest < MiniTest::Unit::TestCase
     patient = Record.new
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/clinical_trial_participant_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    HealthDataStandards::Import::Cat1::PatientImporter.instance.get_clinical_trial_participant(patient, doc)
+    HealthDataStandards::Import::Cat1::PatientImporter.instance.get_clinical_trial_participant(patient, cat1_patient_data_section(doc))
     assert patient.clinicalTrialParticipant
   end
 
@@ -216,7 +216,7 @@ class PatientImporterTest < MiniTest::Unit::TestCase
     patient = Record.new
     doc = Nokogiri::XML(File.new('test/fixtures/cat1_fragments/care_goal_fragment.xml'))
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    HealthDataStandards::Import::Cat1::PatientImporter.instance.get_clinical_trial_participant(patient, doc)
+    HealthDataStandards::Import::Cat1::PatientImporter.instance.get_clinical_trial_participant(patient, cat1_patient_data_section(doc))
     assert !patient.clinicalTrialParticipant
   end
 
@@ -278,7 +278,7 @@ class PatientImporterTest < MiniTest::Unit::TestCase
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
     doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
     patient = Record.new
-    HealthDataStandards::Import::Cat1::PatientImporter.instance.import_sections(patient, doc)
+    HealthDataStandards::Import::Cat1::PatientImporter.instance.import_sections(patient, cat1_patient_data_section(doc))
     patient
   end
 

--- a/test/unit/import/cat1/procedure_intolerance_importer_test.rb
+++ b/test/unit/import/cat1/procedure_intolerance_importer_test.rb
@@ -7,7 +7,7 @@ class ProcedureIntoleranceImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     p_i = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::ProcedureIntoleranceImporter.new, '2.16.840.1.113883.3.560.1.61')
-    procedure_intolerances = p_i.package_entries(doc, nrh)
+    procedure_intolerances = p_i.package_entries(cat1_patient_data_section(doc), nrh)
     procedure_intolerance = procedure_intolerances[0]
     assert procedure_intolerance.codes['CPT'].include?('90668')
   end

--- a/test/unit/import/cat1/procedure_order_importer_test.rb
+++ b/test/unit/import/cat1/procedure_order_importer_test.rb
@@ -7,7 +7,7 @@ class ProcedureOrderImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     p_o = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::ProcedureOrderImporter.new, '2.16.840.1.113883.3.560.1.62', 'ordered')
-    procedure_orders = p_o.package_entries(doc, nrh)
+    procedure_orders = p_o.package_entries(cat1_patient_data_section(doc), nrh)
     procedure_order = procedure_orders[0]
     assert procedure_order.codes['CPT'].include?('90870')
     assert procedure_order.oid

--- a/test/unit/import/cat1/procedure_performed_importer_test.rb
+++ b/test/unit/import/cat1/procedure_performed_importer_test.rb
@@ -7,7 +7,7 @@ class ProcedurePerformedImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     p_p= HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::ProcedurePerformedImporter.new, '2.16.840.1.113883.3.560.1.6', 'ordered')
-    procedures_performed = p_p.package_entries(doc, nrh)
+    procedures_performed = p_p.package_entries(cat1_patient_data_section(doc), nrh)
     procedure_performed = procedures_performed[0]
     assert procedure_performed.codes['SNOMED-CT'].include?('236211007')
     assert procedure_performed.ordinality['SNOMED-CT'].include?('63161005')

--- a/test/unit/import/cat1/symptom_active_importer_test.rb
+++ b/test/unit/import/cat1/symptom_active_importer_test.rb
@@ -7,7 +7,7 @@ class SymptomActiveImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     symp = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::SymptomActiveImporter.new, '2.16.840.1.113883.3.560.1.69', 'active')
-    symptoms = symp.package_entries(doc, nrh)
+    symptoms = symp.package_entries(cat1_patient_data_section(doc), nrh)
     symptom_active = symptoms[0]
     assert symptom_active.codes['SNOMED-CT'].include?('95815000')
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19930215222215')

--- a/test/unit/import/cat1/tobacco_use_importer_test.rb
+++ b/test/unit/import/cat1/tobacco_use_importer_test.rb
@@ -7,7 +7,7 @@ class TobaccoUseImporterTest < MiniTest::Unit::TestCase
     nrh = HealthDataStandards::Import::CDA::NarrativeReferenceHandler.new
     nrh.build_id_map(doc)
     tbac_use = HealthDataStandards::Import::Cat1::EntryPackage.new(HealthDataStandards::Import::Cat1::TobaccoUseImporter.new, '2.16.840.1.113883.3.560.1.1001', 'completed')
-    tobacco_use_entries = tbac_use.package_entries(doc, nrh)
+    tobacco_use_entries = tbac_use.package_entries(cat1_patient_data_section(doc), nrh)
     tobacco_use = tobacco_use_entries[0]
     assert tobacco_use.codes['SNOMED-CT'].include?('87739003')
     assert tobacco_use.oid


### PR DESCRIPTION
....  This should imporve the performance of the importer as the old statements where essentially looking through every node in the document. Note this does not do anything for ccda cda or c32 importers
