### PR TITLE
Fix display of representedCustodianOrganization in QRDA Cat III

### DIFF
--- a/templates/cat3/_author.cat3.erb
+++ b/templates/cat3/_author.cat3.erb
@@ -22,7 +22,7 @@
        </assignedAuthoringDevice>
       <% end %> 
      
-     <%== render :partial=>"organization", :locals=>{organization: author.organization} %>
+     <%== render :partial=>"organization", :locals=>{organization: author.organization, tag_name: "representedOrganization"} %>
 
     </assignedAuthor>
   </author>

--- a/templates/cat3/_organization.cat3.erb
+++ b/templates/cat3/_organization.cat3.erb
@@ -1,4 +1,3 @@
-<% tag_name ||= "representedOrganization" %>
 <<%=tag_name %>>
   <!-- Represents unique registry organization TIN -->
    <%== render :partial=>"id", :collection=>organization.ids, :id=> "identifier" %>

--- a/templates/cat3/show.cat3.erb
+++ b/templates/cat3/show.cat3.erb
@@ -64,7 +64,7 @@
         </name>
      </assignedPerson>
 
-      <%== render :partial=>"organization", :locals=>{organization: header.legal_authenticator.organization} %>
+      <%== render :partial=>"organization", :locals=>{organization: header.legal_authenticator.organization, tag_name: "representedOrganization"} %>
     </assignedEntity>
   </legalAuthenticator>
 


### PR DESCRIPTION
It appears that the tag_name variable in the _organization template
was not working properly. For the assignedCustodian, the element name
is supposed to be representedCustodianOrganization but it was using
the default of representedOrganization. This change removes the
default value and passes in the tag name with each call to the
partial.
