### PR TITLE
Measure prefilter

### DIFF
--- a/lib/health-data-standards.rb
+++ b/lib/health-data-standards.rb
@@ -53,7 +53,7 @@ require_relative 'health-data-standards/models/medication'
 require_relative 'health-data-standards/models/procedure'
 require_relative 'health-data-standards/models/lab_result'
 require_relative 'health-data-standards/models/functional_status'
-require_relative 'health-data-standards/models/medical_equipment'  
+require_relative 'health-data-standards/models/medical_equipment'
 require_relative 'health-data-standards/models/record'
 require_relative 'health-data-standards/models/personable'
 require_relative 'health-data-standards/models/provider'
@@ -88,6 +88,7 @@ require_relative 'health-data-standards/models/qrda/header'
 require_relative 'health-data-standards/models/cqm/aggregate_objects'
 require_relative 'health-data-standards/models/cqm/query_cache'
 require_relative 'health-data-standards/models/cqm/bundle'
+require_relative 'health-data-standards/models/cqm/prefilter'
 require_relative 'health-data-standards/models/cqm/measure'
 require_relative 'health-data-standards/models/cqm/patient_cache'
 
@@ -149,7 +150,7 @@ require_relative 'health-data-standards/import/green_c32/encounter_importer'
 require_relative 'health-data-standards/import/green_c32/medication_importer'
 require_relative 'health-data-standards/import/green_c32/allergy_importer'
 require_relative 'health-data-standards/import/green_c32/social_history_importer'
-require_relative 'health-data-standards/import/green_c32/immunization_importer' 
+require_relative 'health-data-standards/import/green_c32/immunization_importer'
 require_relative 'health-data-standards/import/green_c32/support_importer'
 require_relative 'health-data-standards/import/green_c32/advance_directive_importer'
 require_relative 'health-data-standards/import/green_c32/medical_equipment_importer'
@@ -186,7 +187,7 @@ module HealthDataStandards
 end
 
 if defined?(Rails)
-  require_relative 'health-data-standards/railtie' 
+  require_relative 'health-data-standards/railtie'
 else
   HealthDataStandards.logger = Log4r::Logger.new("Health Data Standards")
   HealthDataStandards.logger.outputters = Log4r::Outputter.stdout

--- a/lib/health-data-standards/models/cqm/measure.rb
+++ b/lib/health-data-standards/models/cqm/measure.rb
@@ -140,6 +140,19 @@ module HealthDataStandards
         @crit
       end
 
+      # Builds the query hash to pass to MongoDB
+      # Calling this method will create Prefilters if they do not exist on the
+      # measure
+      def prefilter_query!(effective_time)
+        self.build_pre_filters! if self.prefilters.empty?
+
+        if self.prefilters.count == 1
+          self.prefilters.first.build_query_hash(effective_time)
+        else
+          {'$and' => self.prefilters.map {|pf| pf.build_query_hash(effective_time)}}
+        end
+      end
+
       # For submeasures, this will return something like IPP_1
       def ipp_id
         ipp_hqmf_id = self.population_ids['IPP']

--- a/lib/health-data-standards/models/cqm/measure.rb
+++ b/lib/health-data-standards/models/cqm/measure.rb
@@ -5,6 +5,7 @@ module HealthDataStandards
       include Mongoid::Timestamps
 
       MSRPOPL = 'MSRPOPL'
+      SECONDS_IN_A_YEAR = 365*24*60*60
 
       store_in collection: 'measures'
       field :id, type: String
@@ -29,6 +30,9 @@ module HealthDataStandards
       field :populations, type: Array
       field :preconditions, type: Hash
       field :hqmf_document, type: Hash
+
+      embeds_many :prefilters
+
       scope :top_level_by_type , ->(type){where({"type"=> type}).any_of({"sub_id" => nil}, {"sub_id" => "a"})}
       scope :top_level , any_of({"sub_id" => nil}, {"sub_id" => "a"})
       scope :order_by_id_sub_id, order_by([["id", :asc],["sub_id", :asc]])
@@ -134,6 +138,62 @@ module HealthDataStandards
           end
         end
         @crit
+      end
+
+      # For submeasures, this will return something like IPP_1
+      def ipp_id
+        ipp_hqmf_id = self.population_ids['IPP']
+        pop_id, pop_criteria = hqmf_document['population_criteria'].find do |population_id, population_criteria|
+          population_criteria['hqmf_id'] == ipp_hqmf_id
+        end
+        pop_id
+      end
+
+      def build_pre_filters!
+        dc = self.data_criteria.inject({}) do |all_dc, single_dc|
+          key = single_dc.keys.first
+          value = single_dc.values.first
+          all_dc[key] = value
+          all_dc
+        end
+        dc.each_pair do |criteria_name, data_criteria|
+          if data_criteria['definition'] == 'patient_characteristic_birthdate'
+            if data_criteria_in_population?(self.ipp_id, criteria_name)
+              prefilter = Prefilter.new(record_field: 'birthdate',
+                                        effective_time_based: true)
+              if data_criteria['temporal_references']
+                data_criteria['temporal_references'].each do |tr|
+                  if tr['type'] == 'SBS' && tr['reference'] == 'MeasurePeriod'
+                    years = nil
+                    if tr['range']['high']
+                      prefilter.comparison = '$lte'
+                      years = tr['range']['high']['value'].to_i
+                    elsif tr['range']['low']
+                      prefilter.comparison = '$gte'
+                      years = tr['range']['low']['value'].to_i
+                    end
+
+                    prefilter.effective_time_offset = -((1 + years) * SECONDS_IN_A_YEAR)
+                    self.prefilters << prefilter
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+
+      private
+
+      def data_criteria_in_population?(population_id, criteria_name)
+        criteria_in_precondition?(self.hqmf_document['population_criteria'][population_id]['preconditions'], criteria_name)
+      end
+
+      def criteria_in_precondition?(preconditions, criteria_name)
+        preconditions.any? do |precondition|
+          (precondition['reference'] == criteria_name) ||
+          (precondition['preconditions'] && criteria_in_precondition?(precondition['preconditions'], criteria_name))
+        end
       end
     end
   end

--- a/lib/health-data-standards/models/cqm/measure.rb
+++ b/lib/health-data-standards/models/cqm/measure.rb
@@ -149,7 +149,11 @@ module HealthDataStandards
         if self.prefilters.count == 1
           self.prefilters.first.build_query_hash(effective_time)
         else
-          {'$and' => self.prefilters.map {|pf| pf.build_query_hash(effective_time)}}
+          self.prefilters.inject({}) do |query, pf|
+            query.merge(pf.build_query_hash(effective_time)) do |key, new_val, old_val|
+              new_val.merge(old_val)
+            end
+          end
         end
       end
 
@@ -179,10 +183,10 @@ module HealthDataStandards
                   if tr['type'] == 'SBS' && tr['reference'] == 'MeasurePeriod'
                     years = nil
                     if tr['range']['high']
-                      prefilter.comparison = '$lte'
+                      prefilter.comparison = '$gte'
                       years = tr['range']['high']['value'].to_i
                     elsif tr['range']['low']
-                      prefilter.comparison = '$gte'
+                      prefilter.comparison = '$lte'
                       years = tr['range']['low']['value'].to_i
                     end
 

--- a/lib/health-data-standards/models/cqm/prefilter.rb
+++ b/lib/health-data-standards/models/cqm/prefilter.rb
@@ -1,0 +1,31 @@
+module HealthDataStandards
+  module CQM
+    class Prefilter
+      include Mongoid::Document
+      # What field on the Record do we want to compare against
+      field :record_field, type: String
+      # greater than, less than, etc.
+      field :comparison, type: String
+      # Is it based on the effective_time, like 65yo during measure period
+      field :effective_time_based, type: Boolean, default: false
+      # If effective_time_based, what is the offset from effective_time
+      field :effective_time_offset, type: Integer
+      # Comparison to a plain old value, like gender == 'F'
+      field :desired_value
+
+      def build_query_hash(effective_time)
+        filter_value = if self.effective_time_based
+          effective_time + effective_time_offset
+        else
+          self.desired_value
+        end
+
+        if self.comparison == '$eq'
+          {self.record_field => desired_value}
+        else
+          {self.record_field => {self.comparison => filter_value}}
+        end
+      end
+    end
+  end
+end

--- a/test/unit/models/cqm/measure_test.rb
+++ b/test/unit/models/cqm/measure_test.rb
@@ -13,24 +13,24 @@ class MeasureTest < ActiveSupport::TestCase
     categories = HealthDataStandards::CQM::Measure.categories
     assert categories.any? {|c| c['category'] == 'Core' && c['measures'].size == 1}
     assert categories.any? {|c| c['category'] == 'General Practice Adult' && c['measures'].size == 1}
-    assert categories.any? do |c| 
-      c['category'] == 'General Practice Adult' && 
+    assert categories.any? do |c|
+      c['category'] == 'General Practice Adult' &&
       c['measures'].first['title'] == "Pneumonia Vaccination Status for Older Adults"
     end
-    
+
   end
 
   test "Should have key" do
     assert @measure.key == "0001"
   end
-  
+
   test "Should have measure id" do
     assert @measure.measure_id == "0001"
   end
-  
+
   test "Should list installed measures" do
     measures = HealthDataStandards::CQM::Measure.installed
-  
+
     assert_equal 23, measures.count, "there should be 23 measures"
     assert measures.index{|m| m.measure_id=="0001"} != nil
     assert measures.index{|m| m.measure_id=="0002"} != nil
@@ -39,16 +39,27 @@ class MeasureTest < ActiveSupport::TestCase
 
   test "Should list top levels" do
     measures = HealthDataStandards::CQM::Measure.top_level
-    
+
     assert_equal 12, measures.count, "should count 12 top level measures "
     assert measures.where(:hqmf_id=>"0001").count() == 1, "Top level measure 0001 Not Found"
     assert measures.where(:hqmf_id=>"0002").count() == 1, "Top level measure 0002 Not Found"
     assert measures.where(:hqmf_id=>"0348").count() == 1, "Top level measure 0348 Not Found"
   end
-  
+
 
   test "all data criteria" do
     adc = @measure.all_data_criteria
     assert adc.any? {|dc| dc.title == "Office Visit"}
+  end
+
+  test 'building prefilters' do
+    measure = HealthDataStandards::CQM::Measure.where(nqf_id: '0043').first
+    assert measure
+    measure.build_pre_filters!
+    assert_equal 1, measure.prefilters.count
+    pf = measure.prefilters.first
+    assert_equal 'birthdate', pf.record_field
+    assert_equal '$gte', pf.comparison
+    assert_equal -(66 * 365 * 24 * 60 * 60), pf.effective_time_offset
   end
 end

--- a/test/unit/models/cqm/measure_test.rb
+++ b/test/unit/models/cqm/measure_test.rb
@@ -61,7 +61,7 @@ class MeasureTest < ActiveSupport::TestCase
     assert_equal 1, measure.prefilters.count
     pf = measure.prefilters.first
     assert_equal 'birthdate', pf.record_field
-    assert_equal '$gte', pf.comparison
+    assert_equal '$lte', pf.comparison
     assert_equal -(66 * SECONDS_IN_A_YEAR), pf.effective_time_offset
   end
 
@@ -70,7 +70,6 @@ class MeasureTest < ActiveSupport::TestCase
     assert measure
     query_hash = measure.prefilter_query!(0)
 
-    assert query_hash['$and'].include?({'birthdate' => {'$gte' => -(4 * SECONDS_IN_A_YEAR)}})
-    assert query_hash['$and'].include?({'birthdate' => {'$lte' => -(18 * SECONDS_IN_A_YEAR)}})
+    assert_equal({'birthdate' => {'$lte' => -(4 * SECONDS_IN_A_YEAR), '$gte' => -(18 * SECONDS_IN_A_YEAR)}}, query_hash)
   end
 end

--- a/test/unit/models/cqm/measure_test.rb
+++ b/test/unit/models/cqm/measure_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class MeasureTest < ActiveSupport::TestCase
+  SECONDS_IN_A_YEAR = 365 * 24 * 60 * 60
+
   setup do
     dump_database
 
@@ -60,6 +62,15 @@ class MeasureTest < ActiveSupport::TestCase
     pf = measure.prefilters.first
     assert_equal 'birthdate', pf.record_field
     assert_equal '$gte', pf.comparison
-    assert_equal -(66 * 365 * 24 * 60 * 60), pf.effective_time_offset
+    assert_equal -(66 * SECONDS_IN_A_YEAR), pf.effective_time_offset
+  end
+
+  test 'prefilter hash' do
+    measure = HealthDataStandards::CQM::Measure.where(hqmf_id: '8A4D92B2-397A-48D2-0139-7CC6B5B8011E').first
+    assert measure
+    query_hash = measure.prefilter_query!(0)
+
+    assert query_hash['$and'].include?({'birthdate' => {'$gte' => -(4 * SECONDS_IN_A_YEAR)}})
+    assert query_hash['$and'].include?({'birthdate' => {'$lte' => -(18 * SECONDS_IN_A_YEAR)}})
   end
 end

--- a/test/unit/models/cqm/prefilter_test.rb
+++ b/test/unit/models/cqm/prefilter_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class PrefilterTest < ActiveSupport::TestCase
+  setup do
+    @prefilter = HealthDataStandards::CQM::Prefilter.new(record_field: 'birthdate',
+                              effective_time_based: true, comparison: '$gte',
+                              effective_time_offset: -(5 * 365 * 24 * 60 * 60))
+  end
+
+  test 'build query hash for effective time based prefilter' do
+    query_hash = @prefilter.build_query_hash(1000)
+    assert query_hash['birthdate']
+    assert_equal 1000-(5 * 365 * 24 * 60 * 60), query_hash['birthdate']['$gte']
+  end
+end


### PR DESCRIPTION
This adds functionality to the Measure model so that it can create a MongoDB query that will act as a prefilter to the CQM map reduce jobs. Initially it works by building filters based on IPP birth date restrictions. It provides a significant performance boost because you can often skip passing a large portion of the records in the database to the map reduce job.
