### PR TITLE
ThingWithCodes is already included by Entry.

### DIFF
--- a/lib/health-data-standards/models/insurance_provider.rb
+++ b/lib/health-data-standards/models/insurance_provider.rb
@@ -1,6 +1,5 @@
 class InsuranceProvider < Entry
   include Mongoid::Document
-  include ThingWithCodes
   
   embedded_in :record, class_name: 'Record'
   embeds_one :payer, class_name: "Organization"


### PR DESCRIPTION
 Including it again causes an error with mongoid4 because the field codes is being redeclared. Removing the duplicate include stops the error and does not seem to cause any additional issues.
