### PR TITLE
Fixing date calculations in the prefilters

### DIFF
--- a/lib/health-data-standards/models/cqm/measure.rb
+++ b/lib/health-data-standards/models/cqm/measure.rb
@@ -5,7 +5,6 @@ module HealthDataStandards
       include Mongoid::Timestamps
 
       MSRPOPL = 'MSRPOPL'
-      SECONDS_IN_A_YEAR = 365*24*60*60
 
       store_in collection: 'measures'
       field :id, type: String
@@ -190,7 +189,7 @@ module HealthDataStandards
                       years = tr['range']['low']['value'].to_i
                     end
 
-                    prefilter.effective_time_offset = -((1 + years) * SECONDS_IN_A_YEAR)
+                    prefilter.effective_time_offset = 1 + years
                     self.prefilters << prefilter
                   end
                 end

--- a/lib/health-data-standards/models/cqm/prefilter.rb
+++ b/lib/health-data-standards/models/cqm/prefilter.rb
@@ -8,7 +8,7 @@ module HealthDataStandards
       field :comparison, type: String
       # Is it based on the effective_time, like 65yo during measure period
       field :effective_time_based, type: Boolean, default: false
-      # If effective_time_based, what is the offset from effective_time
+      # If effective_time_based, what is the offset from effective_time in years
       field :effective_time_offset, type: Integer
       # Comparison to a plain old value, like gender == 'F'
       field :desired_value
@@ -17,7 +17,8 @@ module HealthDataStandards
 
       def build_query_hash(effective_time)
         filter_value = if self.effective_time_based
-          effective_time + effective_time_offset
+          et = Time.at(effective_time)
+          et.years_ago(effective_time_offset).to_i
         else
           self.desired_value
         end

--- a/test/unit/models/cqm/measure_test.rb
+++ b/test/unit/models/cqm/measure_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class MeasureTest < ActiveSupport::TestCase
-  SECONDS_IN_A_YEAR = 365 * 24 * 60 * 60
-
   setup do
     dump_database
 
@@ -62,14 +60,15 @@ class MeasureTest < ActiveSupport::TestCase
     pf = measure.prefilters.first
     assert_equal 'birthdate', pf.record_field
     assert_equal '$lte', pf.comparison
-    assert_equal -(66 * SECONDS_IN_A_YEAR), pf.effective_time_offset
+    assert_equal 66, pf.effective_time_offset
   end
 
   test 'prefilter hash' do
     measure = HealthDataStandards::CQM::Measure.where(hqmf_id: '8A4D92B2-397A-48D2-0139-7CC6B5B8011E').first
     assert measure
     query_hash = measure.prefilter_query!(0)
-
-    assert_equal({'birthdate' => {'$lte' => -(4 * SECONDS_IN_A_YEAR), '$gte' => -(18 * SECONDS_IN_A_YEAR)}}, query_hash)
+    lte = Time.at(0).years_ago(4).to_i
+    gte = Time.at(0).years_ago(18).to_i
+    assert_equal({'birthdate' => {'$lte' => lte, '$gte' => gte}}, query_hash)
   end
 end

--- a/test/unit/models/cqm/prefilter_test.rb
+++ b/test/unit/models/cqm/prefilter_test.rb
@@ -4,12 +4,13 @@ class PrefilterTest < ActiveSupport::TestCase
   setup do
     @prefilter = HealthDataStandards::CQM::Prefilter.new(record_field: 'birthdate',
                               effective_time_based: true, comparison: '$gte',
-                              effective_time_offset: -(5 * 365 * 24 * 60 * 60))
+                              effective_time_offset: 5)
   end
 
   test 'build query hash for effective time based prefilter' do
     query_hash = @prefilter.build_query_hash(1000)
+    expexted_time = Time.at(1000).years_ago(5).to_i
     assert query_hash['birthdate']
-    assert_equal 1000-(5 * 365 * 24 * 60 * 60), query_hash['birthdate']['$gte']
+    assert_equal expexted_time, query_hash['birthdate']['$gte']
   end
 end


### PR DESCRIPTION
Previously, when calculating the dates for prefilters, we were
calculating a year as just 365 days. This new code uses actual date
functions to account for things like leap years.
