### PR TITLE
Correctly handle "Concurrent" with Measurement Period Start or End

### DIFF
--- a/lib/hqmf-model/types.rb
+++ b/lib/hqmf-model/types.rb
@@ -213,7 +213,7 @@ module HQMF
   class TemporalReference
     include HQMF::Conversion::Utilities
     
-    TYPES = ['DURING','SBS','SAS','SBE','SAE','EBS','EAS','EBE','EAE','SDU','EDU','ECW','SCW','CONCURRENT']
+    TYPES = ['DURING','SBS','SAS','SBE','SAE','EBS','EAS','EBE','EAE','SDU','EDU','ECW','ECWS','SCW','SCWE','CONCURRENT']
     INVERSION = {'SBS' => 'SAS','EAE' => 'EBE','SAS' => 'SBS','EBE' => 'EAE','SBE' => 'EAS','EAS' => 'SBE','SAE' => 'EBS','EBS' => 'SAE'}
     
     attr_reader :type, :reference, :range

--- a/lib/hqmf-parser/converter/pass1/precondition_extractor.rb
+++ b/lib/hqmf-parser/converter/pass1/precondition_extractor.rb
@@ -47,15 +47,19 @@ module HQMF
       # if we reference the measurement period, then we want to check if the reference is to the start or end of the measurement period
       # if we SBS of the END of the measurement period, we want to convert that to SBE of the measurement period
       if target_id == HQMF::Document::MEASURE_PERIOD_ID
-        references_start = {'SBS'=>'SBE','SAS'=>'SAE','EBS'=>'EBE','EAS'=>'EAE'}
-        references_end = {'EBE'=>'EBS','EAE'=>'EAS','SBE'=>'SBS','SAE'=>'SAS'}
+        references_start = {'SBS'=>'SBE','SAS'=>'SAE','EBS'=>'EBE','EAS'=>'EAE','SCW'=>'SCWE'}
+        references_end = {'EBE'=>'EBS','EAE'=>'EAS','SBE'=>'SBS','SAE'=>'SAS','ECW'=>'ECWS'}
         if data_criteria_converter.measure_period_v1_keys[:measure_start] == restriction[:target_id] and references_end[type]
           # before or after the END of the measurement period START.  Convert to before or after the START of the measurement period.
           # SAE of MPS => SAS of MP
+          # ends concurrent with measurement period START. Convert to concurrent with START of measurement period.
+          # ECW of MPS => ECWS
           type = references_end[type]
         elsif data_criteria_converter.measure_period_v1_keys[:measure_end] == restriction[:target_id] and references_start[type]
           # before or after the START of the measurement period END.  Convert to before or after the END of the measurement period.
           # SBS of MPE => SBE of MP
+          # starts concurrent with measurement period END. Convert to concurrent with END of measurement period.
+          # SCW of MPE => SCWE
           type = references_start[type]
         end
       end

--- a/test/unit/hqmf/converter/precondition_extractor_test.rb
+++ b/test/unit/hqmf/converter/precondition_extractor_test.rb
@@ -1,0 +1,40 @@
+require_relative '../../../test_helper'
+
+module HQMF
+
+  class PreconditionExtractorTest  < Test::Unit::TestCase
+
+    def setup
+      @data_criteria_converter_stub = OpenStruct.new({ v1_data_criteria_by_id: {
+                                                         "af419470-8365-4dd4-8ab0-8245de8ada73" => OpenStruct.new(id: "MeasurePeriod"),
+                                                         "099fe199-fe83-42fa-8e68-c19067499edf" => OpenStruct.new(id: "MeasurePeriod")
+                                                       },
+                                                       measure_period_v1_keys: {
+                                                         measure_start: "af419470-8365-4dd4-8ab0-8245de8ada73",
+                                                         measure_end: "099fe199-fe83-42fa-8e68-c19067499edf"
+                                                       }
+                                                     })
+    end
+
+    # Make sure that an "Ends Concurrent With Measurement Period Start" is correctly converted to "Ends
+    # Concurrent With Start of Measurement Period"
+    def test_extract_preconditions_from_restrictions_ends_concurrent_with
+      restrictions = [{ type: "ECW", target_id: "af419470-8365-4dd4-8ab0-8245de8ada73", negation: false }]
+      preconditions = HQMF::PreconditionExtractor.extract_preconditions_from_restrictions(restrictions, @data_criteria_converter_stub)
+      preconditions.length.must_equal 1
+      preconditions.first.operator.category.must_equal "TEMPORAL"
+      preconditions.first.operator.type.must_equal "ECWS"
+    end
+
+    # Make sure that a "Starts Concurrent With Measurement Period End" is correctly converted to "Starts
+    # Concurrent With End of Measurement Period"
+    def test_extract_preconditions_from_restrictions_starts_concurrent_with
+      restrictions = [{ type: "SCW", target_id: "099fe199-fe83-42fa-8e68-c19067499edf", negation: false }]
+      preconditions = HQMF::PreconditionExtractor.extract_preconditions_from_restrictions(restrictions, @data_criteria_converter_stub)
+      preconditions.length.must_equal 1
+      preconditions.first.operator.category.must_equal "TEMPORAL"
+      preconditions.first.operator.type.must_equal "SCWE"
+    end
+
+  end
+end


### PR DESCRIPTION
When the HQMF parser sees references to Measurement Period Start and Measurement Period End these are converted to Start of Measurement Period and End of Measurement Period; this commit adds support for the "Concurrent" operators during this conversion, ie SCW MPE -> SCWE MP
