### PR TITLE
decrease memory consumption during import

### DIFF
--- a/lib/health-data-standards/import/bundle/importer.rb
+++ b/lib/health-data-standards/import/bundle/importer.rb
@@ -140,14 +140,12 @@ module HealthDataStandards
 
         def self.unpack_and_store_valuesets(zip, bundle)
           entries = zip.glob(SOURCE_ROOTS[:valuesets])
-          bulk = []
           entries.each_with_index do |entry, index|
             vs = HealthDataStandards::SVS::ValueSet.new(unpack_json(entry))
             vs['bundle_id'] = bundle.id
-            bulk << vs
+            HealthDataStandards::SVS::ValueSet.collection.insert(vs.as_document)
             report_progress('Value Sets', (index*100/entries.length)) if index%10 == 0
           end
-          HealthDataStandards::SVS::ValueSet.collection.insert(bulk.map {|vs| vs.as_document}) unless bulk.empty?
           puts "\rLoading: Value Sets Complete          "
         end
 


### PR DESCRIPTION
The import process loads everything into memory first, then dumps it all into mongo. This exceeds the memory constraints of things like the free EC2 instances, so people might find it hard to use health-data-standards there.

This pull request saves value sets as they come in, lowering memory consumption pretty significantly. After making this change, I was able to get importing to work on a server w/ only 1gb memory.
