### PR TITLE
Add additional information to resolve_provider

### DIFF
--- a/lib/health-data-standards/import/bulk_record_importer.rb
+++ b/lib/health-data-standards/import/bulk_record_importer.rb
@@ -85,8 +85,10 @@ module HealthDataStandards
             return {status: 'error', message: "Document templateId does not identify it as a C32 or CCDA", status_code: 400}
           end
 
+          record = Record.update_or_create(patient_data)
+
           begin
-            providers = CDA::ProviderImporter.instance.extract_providers(doc)
+            providers = CDA::ProviderImporter.instance.extract_providers(doc, record)
           rescue Exception => e
             STDERR.puts "error extracting providers"
           end
@@ -94,7 +96,6 @@ module HealthDataStandards
           return {status: 'error', message: 'Unknown XML Format', status_code: 400}
         end
 
-        record = Record.update_or_create(patient_data)
         record.provider_performances = providers
         providers.each do |prov|
           prov.provider.ancestors.each do |ancestor|

--- a/lib/health-data-standards/import/cda/provider_importer.rb
+++ b/lib/health-data-standards/import/cda/provider_importer.rb
@@ -18,11 +18,11 @@ module HealthDataStandards
         # @param [Nokogiri::XML::Document] doc It is expected that the root node of this document
         #        will have the "cda" namespace registered to "urn:hl7-org:v3"
         # @return [Array] an array of providers found in the document
-        def extract_providers(doc)
+        def extract_providers(doc, patient=nil)
           performers = doc.xpath("//cda:documentationOf/cda:serviceEvent/cda:performer")
           performers.map do |performer|
             provider_perf = extract_provider_data(performer, true)
-            ProviderPerformance.new(start_date: provider_perf.delete(:start), end_date: provider_perf.delete(:end), provider: find_or_create_provider(provider_perf))
+            ProviderPerformance.new(start_date: provider_perf.delete(:start), end_date: provider_perf.delete(:end), provider: find_or_create_provider(provider_perf, patient))
           end
         end
 

--- a/lib/health-data-standards/import/provider_import_utils.rb
+++ b/lib/health-data-standards/import/provider_import_utils.rb
@@ -5,7 +5,7 @@ module ProviderImportUtils
     find_or_create_provider(provider_data)
   end
 
-  def find_or_create_provider(provider_hash)
+  def find_or_create_provider(provider_hash, patient=nil)
     provider = Provider.by_npi(provider_hash[:npi]).first if provider_hash[:npi] && !provider_hash[:npi].empty?
     unless provider
       if provider_hash[:npi]
@@ -22,7 +22,7 @@ module ProviderImportUtils
                             :family_name=> provider_hash[:family_name],
                             :specialty => provider_hash[:specialty]}
         provider ||= Provider.where(provider_query).first
-        provider ||= Provider.resolve_provider(provider_hash)
+        provider ||= Provider.resolve_provider(provider_hash, patient)
         provider ||= Provider.create(provider_hash)
       end
     end

--- a/lib/health-data-standards/models/provider.rb
+++ b/lib/health-data-standards/models/provider.rb
@@ -85,7 +85,7 @@ class Provider
   # exists.  If this method call return nil an attempt will be made to discover
   # the Provider by name matching and if that fails a Provider will be created
   # in the db based on the information in the parsed hash.
-  def self.resolve_provider(provider_hash)
+  def self.resolve_provider(provider_hash, patient=nil)
     Provider.where(:npi => nil).first
   end
 end

--- a/test/unit/import/cda/cda_provider_importer_test.rb
+++ b/test/unit/import/cda/cda_provider_importer_test.rb
@@ -8,7 +8,7 @@ class CDAProviderImporterTest < MiniTest::Unit::TestCase
 	end
 
   def teardown
-    def Provider.resolve_provider(p) 
+    def Provider.resolve_provider(p, q)
     end
     Provider.where({}).delete
   end
@@ -66,7 +66,7 @@ class CDAProviderImporterTest < MiniTest::Unit::TestCase
   end
 
   def test_import_resolve_provider
-    def Provider.resolve_provider(p) 
+    def Provider.resolve_provider(p, q)
       Provider.first
     end
     assert_equal 0, Provider.count, "Should be 0 providers in the DB"


### PR DESCRIPTION
This pull request adds support for other applications to access additional data about records assigned to the orphan provider. This will be used by popHealth to log the ID of each record which is assigned to the orphan provider.
