### PR TITLE
Patient cache tweaks

### DIFF
--- a/lib/health-data-standards/models/cqm/patient_cache.rb
+++ b/lib/health-data-standards/models/cqm/patient_cache.rb
@@ -6,6 +6,7 @@ module HealthDataStandards
       store_in collection: 'patient_cache'
       index "value.last" => 1
       index "bundle_id" => 1
+      index "value.medical_record_id" => 1
       embeds_one :value, class_name: "HealthDataStandards::CQM::PatientCacheValue", inverse_of: :patient_cache
 
       def record

--- a/lib/health-data-standards/models/cqm/patient_cache.rb
+++ b/lib/health-data-standards/models/cqm/patient_cache.rb
@@ -1,61 +1,61 @@
- module HealthDataStandards
-	module CQM
-	  class PatientCache
-			include Mongoid::Document
-			include Mongoid::Timestamps
-	    store_in collection: 'patient_cache'
-			index "value.last" => 1
-	  	index "bundle_id" => 1
-	    embeds_one :value, class_name: "HealthDataStandards::CQM::PatientCacheValue", inverse_of: :patient_cache
+module HealthDataStandards
+  module CQM
+    class PatientCache
+      include Mongoid::Document
+      include Mongoid::Timestamps
+      store_in collection: 'patient_cache'
+      index "value.last" => 1
+      index "bundle_id" => 1
+      embeds_one :value, class_name: "HealthDataStandards::CQM::PatientCacheValue", inverse_of: :patient_cache
 
-		  def record
-		  	Record.where(:medical_record_number => value['medical_record_id'], :test_id => value["test_id"]).first
-		  end
+      def record
+        Record.where(:medical_record_number => value['medical_record_id'], :test_id => value["test_id"]).first
+      end
 
-		  def self.smoking_gun_rational(hqmf_id,sub_ids=nil, filter ={})
+      def self.smoking_gun_rational(hqmf_id, sub_ids=nil, filter ={})
 
-		  	match = {"value.IPP" => {"$gt" => 0},
-		  				   "value.measure_id" => hqmf_id
-		  	}.merge filter
+        match = {"value.IPP" => {"$gt" => 0},
+                 "value.measure_id" => hqmf_id
+        }.merge filter
 
-		  	if sub_ids
-		  		match["value.sub_id"] = {"$in" => sub_ids}
-		  	end
+        if sub_ids
+          match["value.sub_id"] = {"$in" => sub_ids}
+        end
 
-		  	group = {"$group" => {"_id" => "$value.medical_record_id", "rational" => {"$push"=> "$value.rationale"}}}
-		    aggregate = self.mongo_session.command(:aggregate => 'patient_cache', :pipeline => [{"$match" =>match},group])
+        group = {"$group" => {"_id" => "$value.medical_record_id", "rational" => {"$push"=> "$value.rationale"}}}
+        aggregate = self.mongo_session.command(:aggregate => 'patient_cache', :pipeline => [{"$match" =>match},group])
 
-		    merged = {}
-		    aggregate["result"].each do |agg|
-		    	mrn = agg["_id"]
-		    	rational = {}
-		    	merged[mrn] = rational
-		      agg["rational"].each do |r|
-		    		rational.merge! r 
-		    	end
-		    end
+        merged = {}
+        aggregate["result"].each do |agg|
+          mrn = agg["_id"]
+          rational = {}
+          merged[mrn] = rational
+          agg["rational"].each do |r|
+            rational.merge! r
+          end
+        end
 
-		    merged
-		  end
-		end
+        merged
+      end
+    end
 
-	  class PatientCacheValue
+    class PatientCacheValue
 
-		  include Mongoid::Document
+      include Mongoid::Document
 
-		  embedded_in :patient_cache, inverse_of: :value
+      embedded_in :patient_cache, inverse_of: :value
 
-		  field :DENOM, type: Integer
-		  field :NUMER, type: Integer
-		  field :DENEX, type: Integer
-		  field :DENEXCEP, type: Integer
-		  field :MSRPOPL, type: Integer
-		  field :OBSERV
-		  field :antinumerator, type: Integer
-		  field :IPP, type: Integer
-		  field :measure_id, type: String
-		  field :sub_id, type: String\
-		end
+      field :DENOM, type: Integer
+      field :NUMER, type: Integer
+      field :DENEX, type: Integer
+      field :DENEXCEP, type: Integer
+      field :MSRPOPL, type: Integer
+      field :OBSERV
+      field :antinumerator, type: Integer
+      field :IPP, type: Integer
+      field :measure_id, type: String
+      field :sub_id, type: String
+    end
 
-	end
+  end
 end


### PR DESCRIPTION
Cleans up whitespace in the PatientCache file (there were tabs :disappointed:). It then creates an index on medical_record_id. This helps in popHealth when we want to display individual patient pages but there are a lot of patients and measures selected.
