### PR TITLE
Smarter de-duping of encounter entries

### DIFF
--- a/lib/health-data-standards/models/record.rb
+++ b/lib/health-data-standards/models/record.rb
@@ -121,7 +121,7 @@ class Record
   end
 
   def dedup_section!(section)
-    [:results, :procedures].include?(section) ? dedup_section_merging_codes_and_values!(section) : dedup_section_ignoring_content!(section)
+    [:encounters, :procedures, :results].include?(section) ? dedup_section_merging_codes_and_values!(section) : dedup_section_ignoring_content!(section)
   end
   def dedup_record!
     Record::Sections.each {|section| self.dedup_section!(section)}

--- a/test/unit/models/record_test.rb
+++ b/test/unit/models/record_test.rb
@@ -28,7 +28,24 @@ class RecordTest < Minitest::Test
     assert_equal 3, record.encounters.size
   end
 
-  def test_dedup_procedure_section
+  def test_dedup_encounters_section
+    record = Record.new
+    identifier = CDAIdentifier.new(root: '1.2.3.4')
+    value_a = PhysicalQuantityResultValue.new(scalar: 10)
+    value_b = PhysicalQuantityResultValue.new(scalar: 20)
+    record.encounters << Encounter.new(cda_identifier: identifier, codes: {:x => {:y => "z"}}, values: [value_a])
+    record.encounters << Encounter.new(cda_identifier: identifier, codes: {:a => "b", :x => {:z => "a"}}, values: [value_b])
+
+    assert_equal 2, record.encounters.size
+
+    record.dedup_section! :encounters
+
+    assert_equal 1, record.encounters.size
+    assert_equal({:x => {:y => "z", :z => "a"}, :a => "b"}, record.encounters[0].codes)
+    assert_equal([value_a, value_b], record.encounters[0].values)
+  end
+
+  def test_dedup_procedures_section
     record = Record.new
     identifier = CDAIdentifier.new(root: '1.2.3.4')
     value_a = PhysicalQuantityResultValue.new(scalar: 10)


### PR DESCRIPTION
This commit applies the smarter de-duping that fixed issue #89 to encounters. This ensures that clinical data isn't lost when de-duping encounters by merging codes and concatenating values.
