### PR TITLE
Handle specific occurrence reference to Laboratory Test Result's

### DIFF
--- a/lib/hqmf-parser/converter/pass1/data_criteria_converter.rb
+++ b/lib/hqmf-parser/converter/pass1/data_criteria_converter.rb
@@ -174,7 +174,8 @@ module HQMF
       
       # specific occurrences do not properly set the description, so we want to add the definition and status
       if (specific_occurrence)
-        statusText = ", #{status.titleize}" if status
+        # laboratory_test's without a status are actually Result's
+        statusText = status.blank? ? (definition == 'laboratory_test' ? ", Result" : nil) : ", #{status.titleize}"
         description = "#{definition.titleize}#{statusText}: #{description}" 
         specific_occurrence_const = (description.gsub(/\W/,' ').split.collect {|word| word.strip.upcase }).join '_'
       end


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/76617224
### Notes
- set `statusText` to ", Result" if a specific occurrence references a laboratory_test (which is a Result)
### Screenshots
- erroneous three lab test elements
  - ![screen shot 2014-08-20 at 11 17 23 am](https://cloud.githubusercontent.com/assets/456952/3983152/1c331d4e-287d-11e4-846d-fb3c67622321.png)
- correct Result and Performed lab test elements
  - ![screen shot 2014-08-20 at 11 14 19 am](https://cloud.githubusercontent.com/assets/456952/3983153/1c33acd2-287d-11e4-9dd2-16b184c52a9b.png)
