### PR TITLE
Handle specific occurrence reference to Laboratory Test Result

### DIFF
--- a/lib/hqmf-parser/converter/pass1/data_criteria_converter.rb
+++ b/lib/hqmf-parser/converter/pass1/data_criteria_converter.rb
@@ -176,9 +176,9 @@ module HQMF
       if (specific_occurrence)
         if status
           statusText = ", #{status.titleize}"
-        else
+        elsif definition == 'laboratory_test'
           # laboratory_test without a status is actually a Result
-          statusText = ", Result" if definition == 'laboratory_test'
+          statusText = ", Result"
         end
         description = "#{definition.titleize}#{statusText}: #{description}" 
         specific_occurrence_const = (description.gsub(/\W/,' ').split.collect {|word| word.strip.upcase }).join '_'

--- a/lib/hqmf-parser/converter/pass1/data_criteria_converter.rb
+++ b/lib/hqmf-parser/converter/pass1/data_criteria_converter.rb
@@ -174,9 +174,12 @@ module HQMF
       
       # specific occurrences do not properly set the description, so we want to add the definition and status
       if (specific_occurrence)
-        statusText = ", #{status.titleize}" if status
-        # laboratory_test without a status is actually a Result
-        statusText = ", Result" if definition == 'laboratory_test' and status.blank?
+        if status
+          statusText = ", #{status.titleize}"
+        else
+          # laboratory_test without a status is actually a Result
+          statusText = ", Result" if definition == 'laboratory_test'
+        end
         description = "#{definition.titleize}#{statusText}: #{description}" 
         specific_occurrence_const = (description.gsub(/\W/,' ').split.collect {|word| word.strip.upcase }).join '_'
       end

--- a/lib/hqmf-parser/converter/pass1/data_criteria_converter.rb
+++ b/lib/hqmf-parser/converter/pass1/data_criteria_converter.rb
@@ -175,6 +175,8 @@ module HQMF
       # specific occurrences do not properly set the description, so we want to add the definition and status
       if (specific_occurrence)
         statusText = ", #{status.titleize}" if status
+        # laboratory_test without a status is actually a Result
+        statusText = ", Result" if definition == 'laboratory_test' and status.blank?
         description = "#{definition.titleize}#{statusText}: #{description}" 
         specific_occurrence_const = (description.gsub(/\W/,' ').split.collect {|word| word.strip.upcase }).join '_'
       end


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/76617224
### Notes
- set `statusText` to ", Result" if a specific occurrence references a laboratory_test (which is a Result)
### Screenshots
- erroneous three lab test elements
  - ![screen shot 2014-08-20 at 11 17 23 am](https://cloud.githubusercontent.com/assets/456952/3983152/1c331d4e-287d-11e4-846d-fb3c67622321.png)
- correct Result and Performed lab test elements
  - ![screen shot 2014-08-20 at 11 14 19 am](https://cloud.githubusercontent.com/assets/456952/3983153/1c33acd2-287d-11e4-9dd2-16b184c52a9b.png)
