### PR TITLE
deep merge codes

### DIFF
--- a/lib/health-data-standards/models/record.rb
+++ b/lib/health-data-standards/models/record.rb
@@ -111,7 +111,7 @@ class Record
     unique_entries = {}
     self.send(section).each do |entry|
       if unique_entries[entry.identifier]
-        unique_entries[entry.identifier].codes = unique_entries[entry.identifier].codes.deep_merge(entry.codes)
+        unique_entries[entry.identifier].codes = unique_entries[entry.identifier].codes.deep_merge(entry.codes){ |key, old, new| Array.wrap(old) + Array.wrap(new) }
         unique_entries[entry.identifier].values.concat(entry.values)
       else
         unique_entries[entry.identifier] = entry

--- a/test/unit/models/record_test.rb
+++ b/test/unit/models/record_test.rb
@@ -33,7 +33,7 @@ class RecordTest < Minitest::Test
     identifier = CDAIdentifier.new(root: '1.2.3.4')
     value_a = PhysicalQuantityResultValue.new(scalar: 10)
     value_b = PhysicalQuantityResultValue.new(scalar: 20)
-    record.encounters << Encounter.new(cda_identifier: identifier, codes: {:x => {:y => "z"}}, values: [value_a])
+    record.encounters << Encounter.new(cda_identifier: identifier, codes: {:x => {:y => "z", :z => ["c"]}}, values: [value_a])
     record.encounters << Encounter.new(cda_identifier: identifier, codes: {:a => "b", :x => {:z => "a"}}, values: [value_b])
 
     assert_equal 2, record.encounters.size
@@ -41,7 +41,7 @@ class RecordTest < Minitest::Test
     record.dedup_section! :encounters
 
     assert_equal 1, record.encounters.size
-    assert_equal({:x => {:y => "z", :z => "a"}, :a => "b"}, record.encounters[0].codes)
+    assert_equal({:x => {:y => "z", :z => ["c", "a"]}, :a => "b"}, record.encounters[0].codes)
     assert_equal([value_a, value_b], record.encounters[0].values)
   end
 


### PR DESCRIPTION
deep merge should use array wrapping to concatenate, rather than replace, merged values. useful for multiple codes. #186 
