### PR TITLE
Hqmf template bug

### DIFF
--- a/lib/health-data-standards/util/hqmf_template_helper.rb
+++ b/lib/health-data-standards/util/hqmf_template_helper.rb
@@ -14,10 +14,13 @@ module HealthDataStandards
         when "r2"
           path = '../hqmfr2_template_oid_map.json'
         end
-        if @id_map.blank?
+
+        if @id_map.blank? || version != @id_map_version
           template_id_file = File.expand_path(path, __FILE__)
           @id_map = JSON.parse(File.read(template_id_file))
+          @id_map_version = version
         end
+
         @id_map
       end
 

--- a/test/unit/util/hqmf_template_helper_test.rb
+++ b/test/unit/util/hqmf_template_helper_test.rb
@@ -10,4 +10,11 @@ class HQMFTemplateHelperTest < MiniTest::Unit::TestCase
     oid = HealthDataStandards::Util::HQMFTemplateHelper.template_id_by_definition_and_status("intervention", "recommended")
     assert_equal "2.16.840.1.113883.3.560.1.89", oid
   end
+
+  def test_definition_for_template_id_different_versions
+    definition = HealthDataStandards::Util::HQMFTemplateHelper.definition_for_template_id("2.16.840.1.113883.10.20.28.3.56", "r2")
+    assert_equal "patient_characteristic_ethnicity", definition['definition']
+    definition = HealthDataStandards::Util::HQMFTemplateHelper.definition_for_template_id("2.16.840.1.113883.3.560.1.31", "r1")
+    assert_equal "communication_from_provider_to_patient", definition['definition']
+  end
 end


### PR DESCRIPTION
Added a test for, and fix for, a bug that caused the hqmf_template_helper to not work when definitions were requested for both HQMFr1 and HQMFr2 documents in the same context.
