### PR TITLE
remove element that is not part of the qrda template (tobacco screening)

### DIFF
--- a/templates/cat1/_2.16.840.1.113883.10.20.22.4.85.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.22.4.85.cat1.erb
@@ -15,6 +15,5 @@
                          'tag_name' => 'value',
                          'value_set_map' => value_set_map,
                          'extra_content' => "xsi:type=\"CD\" sdtc:valueSet=\"#{value_set_oid}\"") %>
-    <text><%= entry.description %></text>  
   </observation>
 </entry>


### PR DESCRIPTION
The text element is not specified in the Tobacco Use template and is causing validation errors when checked in Cypress. This template was not being used before patients were updated for 2014.
