### PR TITLE
Removed duplicate payer entries, now that insurance_providers is conside...

### DIFF
--- a/templates/cat1/_patient_data.cat1.erb
+++ b/templates/cat1/_patient_data.cat1.erb
@@ -10,8 +10,5 @@
 
           </text>
           <%== render_patient_data(patient, measures) %>
-          <% patient.insurance_providers.each do |entry| %>
-              <%== render(:partial => '2.16.840.1.113883.10.20.24.3.55', :locals => {:entry => entry}) %>
-          <% end %>
         </section>
       </component>


### PR DESCRIPTION
...red a data_criteria Section

Payer entries should now be inserted as a part of `render_patient_data`, rather than through the custom loop.
