### PR TITLE
Added some special cases for some of the fields needed for CMDs in Medic...

### DIFF
--- a/lib/health-data-standards/export/view_helper.rb
+++ b/lib/health-data-standards/export/view_helper.rb
@@ -66,6 +66,7 @@ module HealthDataStandards
       end
       
       def convert_field_to_hash(field, codes)
+        codes = codes[0] if codes.is_a? Array
         if (codes.is_a? Hash)
           clean_hash = {}
           
@@ -96,7 +97,13 @@ module HealthDataStandards
           elsif codes['scalar']
             return "#{codes['scalar']} #{codes['units']}"
           else
-            return codes.map {|hashcode_set, hashcodes| "#{hashcode_set}: #{(hashcodes.respond_to? :join) ? hashcodes.join(', ') : hashcodes.to_s}"}.join(' ')
+            return codes.map do |hashcode_set, hashcodes| 
+              if hashcodes.is_a? Hash
+                "#{hashcode_set}: #{convert_field_to_hash(hashcode_set, hashcodes)}"
+              else
+                "#{hashcode_set}: #{(hashcodes.respond_to? :join) ? hashcodes.join(', ') : hashcodes.to_s}"
+              end
+            end.join(' ')
           end
             
           clean_hash


### PR DESCRIPTION
...ation: Administered

Specifically: 

*FulfillmentHistory was a Hash wrapped in an Array, so if the method sees a `codes` value that is an Array, it will pull out the first element, and proceed on that element. This keeps the Array from just being turned into a String, without any processing.

*AdministrationTiming was a hash with a hash value for the only key, but without an `_id` attribute, so the code to deal with non-id-containing hashes now recurses into hashes in values.
