### PR TITLE
Added dispenseDate to the time formatting block of convert_field_to_hash

### DIFF
--- a/lib/health-data-standards/export/view_helper.rb
+++ b/lib/health-data-standards/export/view_helper.rb
@@ -108,7 +108,7 @@ module HealthDataStandards
             
           clean_hash
         else
-          if codes && (field.match(/Time$/) || field.match(/\_time$/)) 
+          if codes && (field.match(/Time$/) || field.match(/\_time$/) || field.match(/Date$/)) 
             Entry.time_to_s(codes)
           else
             codes.to_s


### PR DESCRIPTION
Fulfillment History has a DispenseDate field within it, that was being rendered as seconds since the epoch. This change matches the Date portion of the name, and renders it as a Time string instead.
