### PR TITLE
Fix variable name mismatch with patient death time in template

### DIFF
--- a/lib/health-data-standards/export/helper/scooped_view_helper.rb
+++ b/lib/health-data-standards/export/helper/scooped_view_helper.rb
@@ -151,7 +151,7 @@ module HealthDataStandards
 
         def handle_patient_expired(patient)
           if patient.expired
-            [OpenStruct.new(start_date: patient.deathdate, id: UUID.generate)]
+            [OpenStruct.new(start_time: patient.deathdate, id: UUID.generate)]
           else
             []
           end


### PR DESCRIPTION
Story:

https://www.pivotaltracker.com/story/show/78738774

Note that the original description is incorrect, the QRDA template for expired patients should _not_ have a high date, this just fixes the part where the existing time was always null.
