### PR TITLE
Allow polymorphism in bulk record importer

### DIFF
--- a/lib/health-data-standards/import/bulk_record_importer.rb
+++ b/lib/health-data-standards/import/bulk_record_importer.rb
@@ -7,7 +7,7 @@ module HealthDataStandards
         failed_dir ||= File.join(source_dir, '../', 'failed_imports')
         files = Dir.glob(File.join(source_dir, '*.*'))
         files.each do |file|
-           BulkRecordImporter.import_file(file,File.new(file).read,failed_dir)
+          self.import_file(file,File.new(file).read,failed_dir)
         end
       end
 
@@ -27,7 +27,7 @@ module HealthDataStandards
             end
             next if entry.directory?
             data = zipfile.read(entry.name)
-            BulkRecordImporter.import_file(entry.name,data,failed_dir)
+            self.import_file(entry.name,data,failed_dir)
           end
         end
 
@@ -60,9 +60,9 @@ module HealthDataStandards
         begin
           ext = File.extname(name)
           if ext == ".json"
-            BulkRecordImporter.import_json(data)
+            self.import_json(data)
           else
-            BulkRecordImporter.import(data)
+            self.import(data)
           end
         rescue
           FileUtils.mkdir_p(File.dirname(File.join(failed_dir,name)))
@@ -88,9 +88,7 @@ module HealthDataStandards
         record.save!
       end
 
-      def self.import(xml_data, provider_map = {})
-        doc = Nokogiri::XML(xml_data)
-
+      def self.import(xml_data, provider_map = {}, doc = Nokogiri::XML(xml_data))
         providers = []
         root_element_name = doc.root.name
 

--- a/lib/health-data-standards/models/record.rb
+++ b/lib/health-data-standards/models/record.rb
@@ -151,7 +151,6 @@ class Record
       if other_val != []
         my_val = self.send(section) || []
         self.send("#{section}=", my_val.concat(other_val))
-        self.dedup_section!(section) unless my_val == []
       end
     end
   end

--- a/templates/cat3/_measure_data.cat3.erb
+++ b/templates/cat3/_measure_data.cat3.erb
@@ -15,6 +15,7 @@
   <entryRelationship typeCode="SUBJ" inversionInd="true">
     <observation classCode="OBS" moodCode="EVN">
       <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      <templateId root="2.16.840.1.113883.10.20.27.3.24"/>
       <code code="MSRAGG" 
         displayName="rate aggregation" 
         codeSystem="2.16.840.1.113883.5.4" 
@@ -44,6 +45,7 @@
       <entryRelationship typeCode="SUBJ" inversionInd="true">
         <observation classCode="OBS" moodCode="EVN">
           <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <templateId root="2.16.840.1.113883.10.20.27.3.24"/>
           <code code="MSRAGG" 
                 displayName="rate aggregation" 
                 codeSystem="2.16.840.1.113883.5.4" 

--- a/test/unit/models/record_test.rb
+++ b/test/unit/models/record_test.rb
@@ -93,4 +93,26 @@ class RecordTest < Minitest::Test
 
     assert_equal 3, record.encounters.size
   end
+
+  def test_merge_record
+    first = Record.new
+    first.first = "Joe"
+    first.expired = false
+    identifier = CDAIdentifier.new(root: '1.2.3.4')
+    first.encounters << Encounter.new
+    first.encounters << Encounter.new(cda_identifier: identifier)
+    first.encounters << Encounter.new(cda_identifier: CDAIdentifier.new(root: 'abcd'))
+
+    second = Record.new
+    second.first = "Ben"
+    second.expired = true
+    #second.encounters << Encounter.new
+    second.encounters << Encounter.new(cda_identifier: identifier)
+    second.encounters << Encounter.new(cda_identifier: CDAIdentifier.new(root: 'foo'))
+
+    first.merge! second
+    assert_equal 4, first.encounters.size
+    assert_equal "Ben", first.first
+    assert_equal true, first.expired
+  end
 end


### PR DESCRIPTION
A lot of EHRs don't follow standards very strictly. So I want to preprocess their files before sending them off to health data standards; it seems like the best way to do this is to let me create a class like

```
  class MyImporter < HealthDataStandards::Import::BulkRecordImporter
    def self.import(xml_data, provider_map = {})
      doc = self.fix_file(xml_data)
      super("", provider_map, doc)
    end
```

This pull request enables that by replacing internal calls to `BulkRecordImporter.X` with `self.X`.
