### PR TITLE
Enable updating records

### DIFF
--- a/lib/health-data-standards/models/record.rb
+++ b/lib/health-data-standards/models/record.rb
@@ -151,7 +151,6 @@ class Record
       if other_val != []
         my_val = self.send(section) || []
         self.send("#{section}=", my_val.concat(other_val))
-        self.dedup_section!(section) unless my_val == []
       end
     end
   end

--- a/test/unit/models/record_test.rb
+++ b/test/unit/models/record_test.rb
@@ -93,4 +93,26 @@ class RecordTest < Minitest::Test
 
     assert_equal 3, record.encounters.size
   end
+
+  def test_merge_record
+    first = Record.new
+    first.first = "Joe"
+    first.expired = false
+    identifier = CDAIdentifier.new(root: '1.2.3.4')
+    first.encounters << Encounter.new
+    first.encounters << Encounter.new(cda_identifier: identifier)
+    first.encounters << Encounter.new(cda_identifier: CDAIdentifier.new(root: 'abcd'))
+
+    second = Record.new
+    second.first = "Ben"
+    second.expired = true
+    #second.encounters << Encounter.new
+    second.encounters << Encounter.new(cda_identifier: identifier)
+    second.encounters << Encounter.new(cda_identifier: CDAIdentifier.new(root: 'foo'))
+
+    first.merge! second
+    assert_equal 4, first.encounters.size
+    assert_equal "Ben", first.first
+    assert_equal true, first.expired
+  end
 end


### PR DESCRIPTION
Currently only demographic attributes like first and last name get updated in `update_or_create`. This is pretty confusing and I don't think it was intended behavior.

This pull request changes that so that entries get updated as well.
