### PR TITLE
Removed pry require from production code

### DIFF
--- a/lib/hqmf-parser.rb
+++ b/lib/hqmf-parser.rb
@@ -1,6 +1,5 @@
 # require
 require 'nokogiri'
-require 'pry'
 require 'json'
 require 'ostruct'
 require 'health-data-standards'


### PR DESCRIPTION
The `require pry` that was in `hqmf-parser.rb` was breaking the Cypress knife installer, as HDS only requires pry in the develop/test groups.
