### PR TITLE
Added helper to generate an identifier string, based on the MD5 of a pas...

### DIFF
--- a/lib/health-data-standards/export/view_helper.rb
+++ b/lib/health-data-standards/export/view_helper.rb
@@ -64,6 +64,10 @@ module HealthDataStandards
       def is_bool?(str)
         return ["true","false"].include? (str || "").downcase
       end
+
+      def identifier_for(obj)
+        Digest::MD5.hexdigest(obj.to_s).upcase
+      end
       
       def convert_field_to_hash(field, codes)
         codes = codes[0] if codes.is_a? Array

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.64.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.64.cat1.erb
@@ -18,6 +18,7 @@
     <entryRelationship typeCode="REFR">
       <procedure classCode="PROC" moodCode="EVN">
         <templateId root="2.16.840.1.113883.10.20.24.3.89"/>
+        <id extension="<%= identifier_for([entry.id, entry.incision_time]) %>" />
         <code code="34896006" 
               codeSystem="2.16.840.1.113883.6.96"
               codeSystemName="SNOMED CT" 

--- a/templates/cat1/_reporting_parameters.cat1.erb
+++ b/templates/cat1/_reporting_parameters.cat1.erb
@@ -13,7 +13,7 @@
             <act classCode="ACT" moodCode="EVN">
               <!-- This is the templateId for Reporting Parameteres Act -->
               <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
-              <id extension="<%= [start_date, end_date].hash %>" />
+              <id extension="<%= identifier_for([start_date, end_date]) %>" />
               <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters"/>
               <effectiveTime>
                 <low value="<%= start_date.to_formatted_s(:number) %>"/>

--- a/templates/cat3/_reporting_parameters.cat3.erb
+++ b/templates/cat3/_reporting_parameters.cat3.erb
@@ -17,7 +17,7 @@
             <act classCode="ACT" moodCode="EVN">
               <!-- This is the templateId for Reporting Parameters Act -->
               <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
-              <id extension="<%= [start_date, end_date].hash %>" />
+              <id extension="<%= identifier_for([start_date, end_date]) %>" />
               <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters"/>
               <effectiveTime>
                 <low value="<%= start_date.to_formatted_s(:number) %>"/>


### PR DESCRIPTION
...sed-in object, and applied that helper at several locations in the cat3 and cat1 templates.

This helps ensure that IDs for these templates are unique, and conform to the HL7 CDA requirements for template IDs, while also being deterministic.
