### PR TITLE
Added ID to reason template 2.16.840.1.113883.10.20.24.3.88

### DIFF
--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.23.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.23.cat1.erb
@@ -75,20 +75,7 @@
     <% end -%>
 
     <% if entry.reason.present? -%>
-    <entryRelationship typeCode="RSON">
-      <observation classCode="OBS" moodCode="EVN">
-        <templateId root="2.16.840.1.113883.10.20.24.3.88"/>  
-        <code code="410666004" 
-              codeSystem="2.16.840.1.113883.6.96"
-              displayName="reason" 
-              codeSystemName="SNOMED CT"/>
-        <statusCode code="completed"/>
-        <effectiveTime <%= value_or_null_flavor(entry.start_time) %>/>
-        <value xsi:type="CD" 
-             code="<%= entry.reason['code'] %>" 
-             codeSystem="<%= HealthDataStandards::Util::CodeSystemHelper.oid_for_code_system(entry.reason['codeSystem'] ||  entry.reason['code_system']) %>"/>
-      </observation>
-    </entryRelationship>
+      <%= render partial: "reason", locals: {entry: entry} %>
     <% end -%>
   </encounter>
 </entry>

--- a/templates/cat1/_reason.cat1.erb
+++ b/templates/cat1/_reason.cat1.erb
@@ -4,7 +4,7 @@
 <entryRelationship typeCode="RSON">
   <observation classCode="OBS" moodCode="EVN">
     <templateId root="2.16.840.1.113883.10.20.24.3.88"/>  
-    <id extension="<%= identifier_for([entry.negation_reason, entry.start_time]) %>"
+    <id extension="<%= identifier_for([entry.negation_reason, entry.start_time]) %>" />
     <code code="410666004" 
           codeSystem="2.16.840.1.113883.6.96"
           displayName="reason" 

--- a/templates/cat1/_reason.cat1.erb
+++ b/templates/cat1/_reason.cat1.erb
@@ -4,6 +4,7 @@
 <entryRelationship typeCode="RSON">
   <observation classCode="OBS" moodCode="EVN">
     <templateId root="2.16.840.1.113883.10.20.24.3.88"/>  
+    <id extension="<%= identifier_for([entry.negation_reason, entry.start_time]) %>"
     <code code="410666004" 
           codeSystem="2.16.840.1.113883.6.96"
           displayName="reason" 


### PR DESCRIPTION
Added an ID, using the new `identifier_for` method, to the reason template, `2.16.840.1.113883.10.20.24.3.88`. 

Also refactored `_2.16.840.1.113883.10.20.24.3.23.cat1.erb` to use the reason template, to reduce code duplication.
