### PR TITLE
Fixed Diagnostic Study Result importing, and Diagnostic Study Result OID mapping

### DIFF
--- a/lib/health-data-standards/export/qrda/hqmf-qrda-oids.json
+++ b/lib/health-data-standards/export/qrda/hqmf-qrda-oids.json
@@ -624,12 +624,6 @@
     "qrda_oid": "2.16.840.1.113883.10.20.24.3.69"
   },
   {
-    "hqmf_name": "Diagnostic Study, Result not done",
-    "hqmf_oid": "2.16.840.1.113883.3.560.1.111",
-    "qrda_name": "Diagnostic Study Result",
-    "qrda_oid": "2.16.840.1.113883.10.20.24.3.20"
-  },
-  {
     "hqmf_name": "Communication: From Provider to Patient not done",
     "hqmf_oid": "2.16.840.1.113883.3.560.1.131",
     "qrda_name": "Communication from Provider to Patient",

--- a/lib/health-data-standards/import/cat1/patient_importer.rb
+++ b/lib/health-data-standards/import/cat1/patient_importer.rb
@@ -42,6 +42,7 @@ module HealthDataStandards
                                              generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.66']", '2.16.840.1.113883.3.560.1.63'),
                                              generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.69']", '2.16.840.1.113883.3.560.1.21'), #risk category assessment
                                              generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.18']", '2.16.840.1.113883.3.560.1.103', 'performed'), #diagnostic study performed
+                                             generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.20']", '2.16.840.1.113883.3.560.1.11'), #diagnostic study result
                                              generate_importer(DiagnosticStudyOrderImporter, nil, '2.16.840.1.113883.3.560.1.40', 'ordered')]
 
           @section_importers[:allergies] = [generate_importer(ProcedureIntoleranceImporter, nil, '2.16.840.1.113883.3.560.1.61'),
@@ -56,7 +57,6 @@ module HealthDataStandards
                                           generate_importer(CDA::ResultImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']", '2.16.840.1.113883.3.560.1.47'), #intervention result
                                           generate_importer(CDA::ResultImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.57']", '2.16.840.1.113883.3.560.1.18'), #physical exam finding
                                           generate_importer(CDA::ResultImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.28']", '2.16.840.1.113883.3.560.1.88'), #functional status result    
-                                          generate_importer(CDA::ResultImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.20']", '2.16.840.1.113883.3.560.1.111'), #diagnostic study result not done
                                           generate_importer(LabResultImporter, nil, '2.16.840.1.113883.3.560.1.12')] #lab result
 
           @section_importers[:encounters] = [generate_importer(EncounterPerformedImporter, "./cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']", '2.16.840.1.113883.3.560.1.79', 'performed'), #encounter performed
@@ -85,6 +85,7 @@ module HealthDataStandards
           nrh.build_id_map(doc)
           @section_importers.each do |section, entry_packages|
             entry_packages.each do |entry_package|
+              # binding.pry if section == :results
               record.send(section) << entry_package.package_entries(context, nrh)
             end
           end

--- a/test/unit/import/cat1/patient_importer_test.rb
+++ b/test/unit/import/cat1/patient_importer_test.rb
@@ -222,7 +222,7 @@ class PatientImporterTest < Minitest::Test
 
   def test_diagnostic_study_result
     patient = build_record_from_xml('test/fixtures/cat1_fragments/diagnostic_study_result_fragment.xml')
-    diag_study_result = patient.results.first
+    diag_study_result = patient.procedures.first
     expected_start = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19890923063243')
     expected_end = HealthDataStandards::Util::HL7Helper.timestamp_to_integer('19890923101231')
     assert diag_study_result.codes['LOINC'].include?('71485-7')


### PR DESCRIPTION
Removed bad OID from mapping/patient_importer, and moved diagnostic study result to 'procedures' rather than 'results', so it will get counted correctly
