### PR TITLE
Removed duplicate reason from communication test update

### DIFF
--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.2.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.2.cat1.erb
@@ -1,16 +1,17 @@
 <entry>
-  <act classCode="ACT" moodCode="EVN" <%== negation_indicator(entry) %>>
+  <act classCode="ACT" moodCode="EVN" <%= negation_indicator(entry) %>>
     <!-- Communication from patient to provider -->
     <templateId root="2.16.840.1.113883.10.20.24.3.2"/>
     <id root="1.3.6.1.4.1.115" extension="<%= entry.id %>"/>  
-    <%== code_display(entry, 'value_set_map' => value_set_map, 'preferred_code_sets' => ['SNOMED-CT'], 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
+    <%= code_display(entry, 'value_set_map' => value_set_map, 'preferred_code_sets' => ['SNOMED-CT'], 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
     <text><%= entry.description %></text>
     <statusCode code="completed"/>
     <effectiveTime>
       <low <%= value_or_null_flavor(entry.start_time) %>/>
       <high <%= value_or_null_flavor(entry.end_time) %>/>
     </effectiveTime>
-    <%== render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
+    
+    <%= render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
 
     <participant typeCode="AUT">
       <participantRole classCode="PAT">
@@ -23,6 +24,8 @@
         <code code="158965000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Medical Practitioner"/>
       </participantRole>
     </participant>
-    <%== render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
+
+    <%= render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
+
   </act>
 </entry>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.2.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.2.cat1.erb
@@ -11,8 +11,6 @@
       <high <%= value_or_null_flavor(entry.end_time) %>/>
     </effectiveTime>
     
-    <%= render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
-
     <participant typeCode="AUT">
       <participantRole classCode="PAT">
         <code code="116154003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Patient"/>

--- a/test/fixtures/cat1_fragments/comm_patient_to_provider_fragment.xml
+++ b/test/fixtures/cat1_fragments/comm_patient_to_provider_fragment.xml
@@ -33,6 +33,17 @@
                 </participantRole>
               </participant>
 
+              <entryRelationship typeCode="RSON">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.24.3.88"/>
+                  <id extension="5B2220FB0B57C9CD39A9AE22C835ACC6"/>
+                  <code code="410666004" codeSystem="2.16.840.1.113883.6.96" displayName="reason" codeSystemName="SNOMED CT"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value="20101027165345"/>
+                  <value xsi:type="CD" code="105480006" codeSystem="2.16.840.1.113883.6.96"/>
+                </observation>
+              </entryRelationship>
+
             </act>
           </entry>
        </section>


### PR DESCRIPTION
According to the CDA schema, the `entryRelationship`s should go after the `participant`s, so that's the one I kept.

Also added a reason `entryRelationship` to the communication test fixture.
