### PR TITLE
Updates for CMD calculation from Medication: Active

### DIFF
--- a/lib/health-data-standards/export/view_helper.rb
+++ b/lib/health-data-standards/export/view_helper.rb
@@ -40,6 +40,14 @@ module HealthDataStandards
         end
       end
 
+      def fulfillment_quantity(codes, fulfillmentHistory, dose)
+        if (codes["RxNorm"].present?)
+          doses = (fulfillmentHistory.quantity_dispensed['value'].to_f / dose['value'].to_f ).to_i
+          return "value='#{doses}'"
+        else
+          return "value='#{fulfillmentHistory.quantity_dispensed['value']}' unit='#{fulfillmentHistory.quantity_dispensed['unit']}'"
+        end
+      end
            
       def value_or_null_flavor(time)
         if time 

--- a/lib/health-data-standards/export/view_helper.rb
+++ b/lib/health-data-standards/export/view_helper.rb
@@ -49,6 +49,14 @@ module HealthDataStandards
        end
       end
 
+      def dose_quantity(codes, dose)
+        if (codes["RxNorm"].present?)
+          return "value='1'"
+        else
+          return "value=#{dose['value']} unit=#{dose['unit']}" 
+        end
+      end
+
       def time_if_not_nil(*args)
         args.compact.map {|t| Time.at(t).utc}.first
       end

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.41.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.41.cat1.erb
@@ -12,9 +12,15 @@
         <low <%= value_or_null_flavor(entry.start_time) %>/>
         <high <%= value_or_null_flavor(entry.end_time) %>/>
     </effectiveTime>
+
+    <% if entry.administrationTiming.present?
+      period = entry.administrationTiming['period'] %>
+      <effectiveTime xsi:type="PIVL_TS" institutionSpecified="true" operator="A">
+        <period value="<%= period['value']%>" unit="<%= period['unit']%>"/>
+      </effectiveTime>
+    <% end %>
     
     <%== render(:partial => 'medication_details', :locals => {:entry => entry, :route_oids=>field_oids["ROUTE"]}) %>
-
 
     <% if entry.product_form.present? -%>
     <administrationUnitCode code="<%= entry.product_form['code'] %>" codeSystem="<%= entry.product_form['codeSystem'] %>"/>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.41.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.41.cat1.erb
@@ -34,5 +34,31 @@
       </manufacturedProduct>
     </consumable>
     <%== render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
+
+    <% if entry.fulfillmentHistory.present?
+    fulfillmentHistory = entry.fulfillmentHistory[0] %>
+    <entryRelationship>
+      <supply classCode="SPLY" moodCode="EVN">
+        <!-- Medication Dispense template -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.18"/>
+        <id root="1.3.6.1.4.1.115" extension="<%= UUID.generate %>"/>
+        <statusCode code="completed"/>
+        <effectiveTime <%= value_or_null_flavor(fulfillmentHistory.dispense_date) %>/>
+        <repeatNumber value="1"/>
+        <quantity <%= fulfillment_quantity(entry.codes, fulfillmentHistory, entry.dose) %>/>
+        <product>
+          <manufacturedProduct classCode="MANU">
+            <!-- Medication Information (consolidation) template -->
+            <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+            <id root="<%= UUID.generate %>"/>
+            <manufacturedMaterial>
+              <%== code_display(entry, 'preferred_code_sets' =>["RxNorm"], 'value_set_map' => value_set_map, 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
+            </manufacturedMaterial>
+          </manufacturedProduct>
+        </product>
+      </supply>
+    </entryRelationship>
+  <% end %>
   </substanceAdministration>
+
 </entry>

--- a/templates/cat1/_medication_details.cat1.erb
+++ b/templates/cat1/_medication_details.cat1.erb
@@ -11,5 +11,5 @@
 <% end -%>
 
 <% if entry.respond_to?(:dose) && entry.dose.present? -%>
-<doseQuantity value="<%= entry.dose['value']%>"/>
+<doseQuantity <%= dose_quantity(entry.codes, entry.dose) %>/>
 <% end -%>


### PR DESCRIPTION
A number of updates for Cumulative Medication Duration calculation from a Medication: Active template. Namely, the addition of `fulfillmentHistory` and `administrationPeriod`, as well as the correct formatting of `doseQuantity` based on if the med code is precoordinated or not.

Fixes Trello tickets #368 (https://trello.com/c/lG05MCeQ) and #367 (https://trello.com/c/DjC2TWqy)
