### PR TITLE
Missed some necessary equals signs in the ERB template for communication...

### DIFF
--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.2.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.2.cat1.erb
@@ -1,9 +1,9 @@
 <entry>
-  <act classCode="ACT" moodCode="EVN" <%= negation_indicator(entry) %>>
+  <act classCode="ACT" moodCode="EVN" <%== negation_indicator(entry) %>>
     <!-- Communication from patient to provider -->
     <templateId root="2.16.840.1.113883.10.20.24.3.2"/>
     <id root="1.3.6.1.4.1.115" extension="<%= entry.id %>"/>  
-    <%= code_display(entry, 'value_set_map' => value_set_map, 'preferred_code_sets' => ['SNOMED-CT'], 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
+    <%== code_display(entry, 'value_set_map' => value_set_map, 'preferred_code_sets' => ['SNOMED-CT'], 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
     <text><%= entry.description %></text>
     <statusCode code="completed"/>
     <effectiveTime>
@@ -23,7 +23,7 @@
       </participantRole>
     </participant>
 
-    <%= render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
+    <%== render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
 
   </act>
 </entry>


### PR DESCRIPTION
...: from patient to provider, which caused output to be escaped, rather than output as XML.

This fix adds those necessary equals signs back in.
