### PR TITLE
Multiple fulfillment events

### DIFF
--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.41.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.41.cat1.erb
@@ -41,30 +41,8 @@
     </consumable>
     <%== render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
 
-    <% if entry.fulfillmentHistory.present?
-    fulfillmentHistory = entry.fulfillmentHistory[0] %>
-    <entryRelationship typeCode="REFR">
-      <supply classCode="SPLY" moodCode="EVN">
-        <!-- Medication Dispense template -->
-        <templateId root="2.16.840.1.113883.10.20.22.4.18"/>
-        <id root="1.3.6.1.4.1.115" extension="<%= UUID.generate %>"/>
-        <statusCode code="completed"/>
-        <effectiveTime <%= value_or_null_flavor(fulfillmentHistory.dispense_date) %>/>
-        <repeatNumber value="1"/>
-        <quantity <%= fulfillment_quantity(entry.codes, fulfillmentHistory, entry.dose) %>/>
-        <product>
-          <manufacturedProduct classCode="MANU">
-            <!-- Medication Information (consolidation) template -->
-            <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
-            <id root="<%= UUID.generate %>"/>
-            <manufacturedMaterial>
-              <%== code_display(entry, 'preferred_code_sets' =>["RxNorm"], 'value_set_map' => value_set_map, 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
-            </manufacturedMaterial>
-          </manufacturedProduct>
-        </product>
-      </supply>
-    </entryRelationship>
-  <% end %>
+    <%== render(:partial => 'medication_dispense', :collection => entry.fulfillmentHistory, :locals => {:entry => entry, :value_set_map => value_set_map, :value_set_oid => value_set_oid}) %>
+
   </substanceAdministration>
 
 </entry>

--- a/templates/cat1/_medication_dispense.cat1.erb
+++ b/templates/cat1/_medication_dispense.cat1.erb
@@ -1,5 +1,5 @@
 
-<entryRelationship>
+<entryRelationship typeCode="REFR">
   <supply classCode="SPLY" moodCode="EVN">
     <!-- Medication Dispense template -->
     <templateId root="2.16.840.1.113883.10.20.22.4.18"/>

--- a/templates/cat1/_medication_dispense.cat1.erb
+++ b/templates/cat1/_medication_dispense.cat1.erb
@@ -1,0 +1,22 @@
+
+<entryRelationship>
+  <supply classCode="SPLY" moodCode="EVN">
+    <!-- Medication Dispense template -->
+    <templateId root="2.16.840.1.113883.10.20.22.4.18"/>
+    <id root="1.3.6.1.4.1.115" extension="<%= UUID.generate %>"/>
+    <statusCode code="completed"/>
+    <effectiveTime <%= value_or_null_flavor(medication_dispense.dispense_date) %>/>
+    <repeatNumber value="1"/>
+    <quantity <%= fulfillment_quantity(entry.codes, medication_dispense, entry.dose) %>/>
+    <product>
+      <manufacturedProduct classCode="MANU">
+        <!-- Medication Information (consolidation) template -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+        <id root="<%= UUID.generate %>"/>
+        <manufacturedMaterial>
+          <%== code_display(entry, 'preferred_code_sets' =>["RxNorm"], 'value_set_map' => value_set_map, 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
+        </manufacturedMaterial>
+      </manufacturedProduct>
+    </product>
+  </supply>
+</entryRelationship>


### PR DESCRIPTION
Updated the medication active template to be able to handle multiple events in the fulfillment history. Before it was just taking the first fulfillment event out of the array and putting that one in the template. Now it will put in as many entryRelationships as there are fulfillmentHistory entries.

Additionally, added a medication_dispense cat1 partial, to facilitate creating entryRelationships for each fulfillment event.
