### PR TITLE
HTML updates for CMD fulfillment history

### DIFF
--- a/lib/health-data-standards/export/view_helper.rb
+++ b/lib/health-data-standards/export/view_helper.rb
@@ -86,7 +86,10 @@ module HealthDataStandards
       end
       
       def convert_field_to_hash(field, codes)
-        codes = codes[0] if codes.is_a? Array
+        if codes.is_a? Array
+          return codes.collect{ |code| convert_field_to_hash(field, convert_field_to_hash(field, code))}.join("<br>")
+        end
+
         if (codes.is_a? Hash)
           clean_hash = {}
           

--- a/templates/html/_entry.html.erb
+++ b/templates/html/_entry.html.erb
@@ -44,17 +44,16 @@
 	  <% 
 	    (entry.attributes.keys.reject {|key| ['codes', 'time', 'description', 'mood_code', 'values', '_id', '_type', 'start_time', 'end_time', 'status_code', 'negationInd', 'oid'].include? key}).sort.each do |field|
       field_value = convert_field_to_hash(field, entry.attributes[field])
-
     %>
         <% if field_value && !field_value.empty? %> 
         <dl>
           <% if field_value.is_a? Hash %>
             <dt><b><%= field.titleize %>:</b></dt>
 	          <% field_value.keys.sort.reverse.each do |fieldkey| %>
-	            <dd><%= fieldkey %>: <i><%= field_value[fieldkey] %></i></dd>
+	            <dd><%= fieldkey %>: <i><%== field_value[fieldkey] %></i></dd>
 	          <% end %>
           <% else %>
-            <dt><b><%= field.titleize %></b>: <%= field_value%></dt>
+            <dt><b><%= field.titleize %></b>: <%== field_value%></dt>
           <% end %>
         <dl>
         <% end %>


### PR DESCRIPTION
Updated the view_helper and _entry template to facilitate arrays of fulfillment histories for CMD. Before it would only display the first medication dispense; now it will display all of them, and input line breaks.
