### PR TITLE
Fixing issue where generic patient characteristic criteria were not bein...

### DIFF
--- a/lib/health-data-standards/export/qrda/entry_template_resolver.rb
+++ b/lib/health-data-standards/export/qrda/entry_template_resolver.rb
@@ -43,7 +43,11 @@ module HealthDataStandards
           elsif vs_oid == "2.16.840.1.113883.3.526.3.1189" || vs_oid == "2.16.840.1.113883.3.526.3.1170" || vs_oid == '2.16.840.1.113883.3.600.2390'
             # Patient Characteristic Tobacco User/Non-User
             '2.16.840.1.113883.10.20.22.4.85'
+          else
+            # return generic pc observation template for anything not specificly mapped to its own template
+            '2.16.840.1.113883.10.20.24.3.103'
           end
+
         end
 
         alias :partial_for :qrda_oid_for_hqmf_oid

--- a/lib/health-data-standards/export/view_helper.rb
+++ b/lib/health-data-standards/export/view_helper.rb
@@ -6,7 +6,16 @@ module HealthDataStandards
         options['attribute'] ||= :codes
         options['exclude_null_flavor'] ||= false
         code_string = nil
-        preferred_code = entry.preferred_code(options['preferred_code_sets'], options['attribute'], options['value_set_map'])
+        # allowing wild card matching of any code system for generic templates
+        #valueset filtering should filter out a decent code 
+        pcs = if options['preferred_code_sets'] && options['preferred_code_sets'].index("*")
+          #all of the code_systems that we know about
+          HealthDataStandards::Util::CodeSystemHelper::CODE_SYSTEMS.values | HealthDataStandards::Util::CodeSystemHelper::CODE_SYSTEM_ALIASES.keys 
+        else
+          options['preferred_code_sets']
+        end
+
+        preferred_code = entry.preferred_code(pcs, options['attribute'], options['value_set_map'])
         if preferred_code
           code_system_oid = HealthDataStandards::Util::CodeSystemHelper.oid_for_code_system(preferred_code['code_set'])
           code_string = "<#{options['tag_name']} code=\"#{preferred_code['code']}\" codeSystem=\"#{code_system_oid}\" #{options['extra_content']}>"

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.103.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.103.cat1.erb
@@ -5,7 +5,7 @@
     <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
     <statusCode code="completed" />
     <effectiveTime <%= value_or_null_flavor(entry.start_time) %>/>
-    <%== code_display(entry, 'preferred_code_sets' => ['SNOMED-CT'],
+    <%== code_display(entry, 'preferred_code_sets' => ['*'],
                              'tag_name' => 'value','value_set_map' => value_set_map,
                              'extra_content' => "xsi:type=\"CD\" sdtc:valueSet=\"#{value_set_oid}\"") %>
     <text><%= entry.description %></text>

--- a/test/unit/export/entry_template_resolver_test.rb
+++ b/test/unit/export/entry_template_resolver_test.rb
@@ -19,7 +19,9 @@ class EntryTemplateResolverTest < Minitest::Test
     assert_equal '2.16.840.1.113883.10.20.24.3.101', HealthDataStandards::Export::QRDA::EntryTemplateResolver.qrda_oid_for_hqmf_patient_characteristic('2.16.840.1.113883.3.117.1.7.1.403')
     assert_equal '2.16.840.1.113883.10.20.22.4.85', HealthDataStandards::Export::QRDA::EntryTemplateResolver.qrda_oid_for_hqmf_patient_characteristic('2.16.840.1.113883.3.526.3.1189')
     assert_equal '2.16.840.1.113883.10.20.22.4.85', HealthDataStandards::Export::QRDA::EntryTemplateResolver.qrda_oid_for_hqmf_patient_characteristic('2.16.840.1.113883.3.526.3.1170')
-
+    #any non mapped vs_oid should return the generic patient characteristic observation template
+    assert_equal '2.16.840.1.113883.10.20.24.3.103', HealthDataStandards::Export::QRDA::EntryTemplateResolver.qrda_oid_for_hqmf_patient_characteristic('any_other_vs_oid')
+    
   end
 
 


### PR DESCRIPTION
...g renderd in qrda cat I documents.  Added ability to set a wild card on preferred code set in rendering template to allow any coded set to be used. Added returning on generic patient characteristic template in view helper when an explicit valueset oid mapping is not avaiable.
