### PR TITLE
The MAT current exports preconditions that reference population criteria...

### DIFF
--- a/lib/hqmf-parser/2.0/document.rb
+++ b/lib/hqmf-parser/2.0/document.rb
@@ -11,6 +11,7 @@ module HQMF2
     # @param [String] path the path to the HQMF document
     def initialize(hqmf_contents)
       @doc = @entry = Document.parse(hqmf_contents)
+      remove_popultaion_preconditions(@doc)
       @id = attr_val('cda:QualityMeasureDocument/cda:id/@extension')
       @hqmf_set_id = attr_val('cda:QualityMeasureDocument/cda:setId/@extension')
       @hqmf_version_number = attr_val('cda:QualityMeasureDocument/cda:versionNumber/@value').to_i
@@ -270,7 +271,14 @@ module HQMF2
        end
     end
 
-    
+    def remove_popultaion_preconditions(doc)
+      #population sections
+      pop_ids = doc.xpath("//cda:populationCriteriaSection/cda:component[@typeCode='COMP']/*/cda:id",NAMESPACES) 
+      #find the population entries and get their ids
+      pop_ids.each do |p_id|
+        doc.xpath("//cda:precondition[./cda:criteriaReference/cda:id[@extension='#{p_id["extension"]}' and @root='#{p_id["root"]}']]",NAMESPACES).remove
+      end
+    end
     private
     
     def find(collection, attribute, value)

--- a/test/fixtures/2.1/measures/fulfills.xml
+++ b/test/fixtures/2.1/measures/fulfills.xml
@@ -3,10 +3,10 @@
                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
          
       <!--
-			**************************************************************
-			Measure Details Section
-			**************************************************************
-		-->
+      **************************************************************
+      Measure Details Section
+      **************************************************************
+    -->
          
       <typeId extension="POQM_HD000001UV02" root="2.16.840.1.113883.1.3"/>
    <templateId>
@@ -359,7 +359,7 @@
                <value valueSet="2.16.840.1.113883.3.117.1.7.1.212" xsi:type="CD">
                   <displayName value="Hemorrhagic Stroke Grouping Value Set"/>
                </value>
-		             <outboundRelationship typeCode="REFR">
+                 <outboundRelationship typeCode="REFR">
                   <observationCriteria classCode="OBS" moodCode="EVN">
                      <templateId>
                         <item extension="2014-11-24" root="2.16.840.1.113883.10.20.28.3.94"/>
@@ -377,7 +377,7 @@
                      </value>
                   </observationCriteria>
                </outboundRelationship>
-	           </observationCriteria>
+             </observationCriteria>
          </entry>
          <!--Diagnosis, Active--><entry typeCode="DRIV">
             <localVariableName value="IschemicStroke_Diagnosis,Active_vMFNU"/>
@@ -395,7 +395,7 @@
                <value valueSet="2.16.840.1.113883.3.117.1.7.1.247" xsi:type="CD">
                   <displayName value="Ischemic Stroke Grouping Value Set"/>
                </value>
-		             <outboundRelationship typeCode="REFR">
+                 <outboundRelationship typeCode="REFR">
                   <observationCriteria classCode="OBS" moodCode="EVN">
                      <templateId>
                         <item extension="2014-11-24" root="2.16.840.1.113883.10.20.28.3.94"/>
@@ -413,7 +413,7 @@
                      </value>
                   </observationCriteria>
                </outboundRelationship>
-	           </observationCriteria>
+             </observationCriteria>
          </entry>
          <!--Medication, Order--><entry typeCode="DRIV">
             <localVariableName value="AntithromboticTherapy_Medication,Order_cTk1B"/>
@@ -425,7 +425,7 @@
                    root="c536bb40-3686-4029-b20d-344b8bfbba90"/>
                <title value="Medication, Order"/>
                <statusCode code="ACTIVE"/>
-	              <participation typeCode="CSM">
+                <participation typeCode="CSM">
                   <role classCode="MANU">
                      <playingMaterial classCode="MMAT" determinerCode="KIND">
                         <code valueSet="2.16.840.1.113883.3.117.1.7.1.201">
@@ -434,7 +434,7 @@
                      </playingMaterial>
                   </role>
                </participation>
-	           </substanceAdministrationCriteria>
+             </substanceAdministrationCriteria>
          </entry>
          <!--Occurrence A Encounter, Performed--><entry typeCode="DRIV">
             <localVariableName value="OccurrenceAofInpatientEncounter_Encounter,Performed_yqcMB"/>
@@ -671,7 +671,7 @@
                <value valueSet="2.16.840.1.113883.3.117.1.7.1.247" xsi:type="CD">
                   <displayName value="Ischemic Stroke Grouping Value Set"/>
                </value>
-		             <temporallyRelatedInformation typeCode="SDU">
+                 <temporallyRelatedInformation typeCode="SDU">
                   <qdm:temporalInformation precisionUnit="min"/>
                   <criteriaReference classCode="ENC" moodCode="EVN">
                      <id extension="OccurrenceA_InpatientEncounter_Encounter,Performed"
@@ -696,7 +696,7 @@
                      </value>
                   </observationCriteria>
                </outboundRelationship>
-	           </observationCriteria>
+             </observationCriteria>
          </entry>
          <!--Clause 'fulfillsClause'--><!--entry for Fulfills--><entry typeCode="DRIV">
             <localVariableName value="IschemicStroke_Diagnosis,Active_vMFNU"/>
@@ -714,7 +714,7 @@
                <value valueSet="2.16.840.1.113883.3.117.1.7.1.247" xsi:type="CD">
                   <displayName value="Ischemic Stroke Grouping Value Set"/>
                </value>
-		             <outboundRelationship typeCode="FLFS">
+                 <outboundRelationship typeCode="FLFS">
                   <criteriaReference classCode="SBADM" moodCode="RQO">
                      <id extension="AntithromboticTherapy_Medication,Order"
                          root="c536bb40-3686-4029-b20d-344b8bfbba90"/>
@@ -738,7 +738,7 @@
                      </value>
                   </observationCriteria>
                </outboundRelationship>
-	           </observationCriteria>
+             </observationCriteria>
          </entry>
       </dataCriteriaSection>
    </component>
@@ -848,6 +848,11 @@
                      codeSystemName="HL7 Observation Value">
                   <displayName value="denominator"/>
                </code>
+               <precondition typeCode="PRCN">
+                  <criteriaReference classCode="OBS" moodCode="EVN">
+                     <id extension="initialPopulation" root="05CB5EF9-FB0E-498F-98FD-805F14AA2B66"/>
+                  </criteriaReference>
+               </precondition>
                <precondition typeCode="PRCN">
                   <criteriaReference classCode="OBS" moodCode="EVN">
                      <id extension="StartsDuring_1A607F93-66CC-48AE-9BB1-70017F809B7D"

--- a/test/unit/hqmf/2.0/document_v2_test.rb
+++ b/test/unit/hqmf/2.0/document_v2_test.rb
@@ -13,6 +13,20 @@ class DocumentV2Test < Test::Unit::TestCase
     @model = doc.to_model
   end
 
+
+  def test_remove_population_preconditions
+     path = File.expand_path("../../../../fixtures/2.1/measures/fulfills.xml", __FILE__)
+     hqmf_contents = File.open(path).read
+     xml = Nokogiri::XML(hqmf_contents)
+     #find the precondition in the parsed document
+     precon = xml.xpath("//cda:precondition[./cda:criteriaReference/cda:id[@extension='initialPopulation' and @root='05CB5EF9-FB0E-498F-98FD-805F14AA2B66']]",HQMF2::Document::NAMESPACES)
+     assert_equal 1, precon.length
+     doc = HQMF2::Document.new(hqmf_contents)
+     doc_xml = doc.instance_variable_get("@doc")
+     precon2 = doc_xml.xpath("//cda:precondition[./cda:criteriaReference/cda:id[@extension='initialPopulation' and @root='05CB5EF9-FB0E-498F-98FD-805F14AA2B66']]",HQMF2::Document::NAMESPACES)
+     assert_equal 0, precon2.length
+  end
+
   def test_roundtrip
     assert_equal 'foo', @model.id
     assert_equal "Statin Prescribed at Discharge", @model.title.strip


### PR DESCRIPTION
....  We currently do not support that concept and the addition of those preconditions causes the parser to throw an error during parsing.  To get around this issue for the time being the preconditions that reference populations will be stripped out of the document before further processing ocurrs
