### PR TITLE
Changes in the importer to deal with new CCDAs

### DIFF
--- a/lib/health-data-standards/import/c32/insurance_provider_importer.rb
+++ b/lib/health-data-standards/import/c32/insurance_provider_importer.rb
@@ -2,13 +2,13 @@ module HealthDataStandards
   module Import
     module C32
       class InsuranceProviderImporter < CDA::SectionImporter
-        
+
         def initialize(entry_finder=CDA::EntryFinder.new("//cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.1.26']"))
           super(entry_finder)
           @check_for_usable = false # needs to be this way becase InsuranceProvider does not respond
                                     # to usable?
         end
-        
+
         def create_entry(payer_element, nrh = CDA::NarrativeReferenceHandler.new)
           ip = InsuranceProvider.new
           type = extract_code(payer_element, "./cda:code")
@@ -21,25 +21,27 @@ module HealthDataStandards
           name = payer_element.at_xpath("./cda:entryRelationship[@typeCode='REFR']/cda:act[@classCode='ACT' and @moodCode='DEF']/cda:text")
           ip.name = name.try(:text)
           patient_element = member_info_element.at_xpath("./cda:participantRole[@classCode='PAT']")
-          ip.member_id = patient_element.at_xpath("./cda:id")
-          ip.relationship = extract_code(patient_element, "./cda:code")
+          if patient_element
+            ip.member_id = patient_element.at_xpath("./cda:id")
+            ip.relationship = extract_code(patient_element, "./cda:code")
+          end
           ip.financial_responsibility_type = extract_code(payer_element, "./cda:performer/cda:assignedEntity/cda:code")
           ip
         end
-        
+
         def extract_guarantors(guarantor_elements)
           guarantor_elements.map do |guarantor_element|
             guarantor = Guarantor.new
-            extract_dates(guarantor_element, guarantor, element_name="time")
+            extract_dates(guarantor_element, guarantor, "time")
             guarantor_entity = guarantor_element.at_xpath("./cda:assignedEntity")
             guarantor.person = import_person(guarantor_entity.at_xpath("./cda:assignedPerson"))
             guarantor.organization = import_organization(guarantor_entity.at_xpath("./cda:representedOrganization"))
             guarantor
           end
         end
-        
+
       end
     end
   end
-  
+
 end


### PR DESCRIPTION
On Intervention Engine, we are importing CCDA documents. Given examples, we ran into a few issues. This PR addresses them:
- Medication importer needed a Mongo connection. This change now checks to see if Mongoid has been configured before it looks up a provider
- The InsuranceProvider importer had a nil safety issue when there is no member info
