### PR TITLE
Clear the @xsd error messages before validating

### DIFF
--- a/lib/health-data-standards/validate/schema_validator.rb
+++ b/lib/health-data-standards/validate/schema_validator.rb
@@ -12,6 +12,7 @@ module HealthDataStandards
 
         # Validate the document against the configured schema
         def validate(document,data={})
+          @xsd.errors.clear
           doc = get_document(document)
           @xsd.validate(doc).map do |error|
             build_error(error.message, "/", data[:file_name])


### PR DESCRIPTION
If we don't do this, the previous document's errors get lumped in with this one's.
