### PR TITLE
handle any string-able input in java schematron validator

### DIFF
--- a/lib/health-data-standards/validate/schematron/java_processor.rb
+++ b/lib/health-data-standards/validate/schematron/java_processor.rb
@@ -26,9 +26,18 @@ module HealthDataStandards
         ISO_SCHEMATRON2 = File.join(DIR, 'resources/schematron/iso-schematron-xslt2/iso_svrl_for_xslt2.xsl')
 
         def get_errors(document)
-          document_j = document.is_a?(File) ? java.io.File.new(document.path) : StringReader.new(document)
+          document_j = get_document_j(document)
           output = build_transformer(StringReader.new(processor), StreamSource.new(document_j))
           Nokogiri::XML(output)
+        end
+
+        def get_document_j(doc)
+          case doc
+          when File
+            java.io.File.new(doc.path)
+          else 
+            StringReader.new(doc.to_s)
+          end
         end
 
         def processor


### PR DESCRIPTION
This will allow us to accept a nokogiri document in the java schematron validator, so we can have nokogiri parse the document once instead of once for every validator.
