### PR TITLE
Include pre-AU2015 CMD field value code for backwards compatibility

### DIFF
--- a/lib/hqmf-model/data_criteria.rb
+++ b/lib/hqmf-model/data_criteria.rb
@@ -62,6 +62,8 @@ module HQMF
                     '410666004' => 'REASON',
                     '260753009' => 'SOURCE',
                     '261773006' => 'CUMULATIVE_MEDICATION_DURATION',
+                    # map pre-AU2015 CMD code to current CMD field definition
+                    '363819003' => 'CUMULATIVE_MEDICATION_DURATION',
                     'SDLOC'     => 'FACILITY_LOCATION',
                     '442864001' => 'DISCHARGE_DATETIME',
                     '309039003' => 'DISCHARGE_STATUS',


### PR DESCRIPTION
### Story
- [BONNIE-87: Errors importing CMS156v3 and CMS179v3 xml files.](https://www.pivotaltracker.com/story/show/94406760)
### Note
- additional CMD code should not impact downstream components since the value is used to perform a lookup for the correct patient API calculation method
