### PR TITLE
Changed code_system_version attribute name to codeSystemVersion

### DIFF
--- a/lib/health-data-standards/models/svs/value_set.rb
+++ b/lib/health-data-standards/models/svs/value_set.rb
@@ -44,7 +44,7 @@ module HealthDataStandards
             code_system_name = HealthDataStandards::Util::CodeSystemHelper::CODE_SYSTEMS[con["codeSystem"]] || con["codeSystemName"]
             Concept.new(code: con["code"], 
                         code_system_name: code_system_name,
-                        code_system_version: con["code_system_version"],
+                        code_system_version: con["codeSystemVersion"],
                         display_name: con["displayName"], code_system: con["codeSystem"])
           end
           vs.concepts = concepts

--- a/test/fixtures/value_sets/value_sets.xml
+++ b/test/fixtures/value_sets/value_sets.xml
@@ -1,21 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-10-23T00:00:00-04:00" xmlns="urn:ihe:iti:svs:2008">
-  <ValueSet id="1.3.6.1.4.1.33895.1.3.0.45" ID="1.3.6.1.4.1.33895.1.3.0.45" version="" displayName="Hospital Measures - Comfort Measures Only Intervention">
-    <ConceptList>
-      <Concept xsi:type="CE" code="103735009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="palliative care" />
-      <Concept xsi:type="CE" code="133918004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="comfort measures" />
-      <Concept xsi:type="CE" code="168528006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="palliative course of radiotherapy" />
-      <Concept xsi:type="CE" code="182964004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="terminal care" />
-      <Concept xsi:type="CE" code="225884000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="talking about dying" />
-      <Concept xsi:type="CE" code="235513003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="palliative procedure for pancreatic pain relief" />
-      <Concept xsi:type="CE" code="284546000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="hospice" />
-      <Concept xsi:type="CE" code="314604005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="palliative course of deep X-ray therapy" />
-      <Concept xsi:type="CE" code="385736008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="dying care" />
-      <Concept xsi:type="CE" code="385763009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="hospice care" />
-      <Concept xsi:type="CE" code="395669003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="specialist palliative care treatment" />
-      <Concept xsi:type="CE" code="395694002" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="specialist palliative care treatment - daycare" />
-      <Concept xsi:type="CE" code="395695001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="specialist palliative care treatment - outpatient" />
-      <Concept xsi:type="CE" code="443761007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="anticipatory palliative care" />
-    </ConceptList>
-  </ValueSet>
-</RetrieveValueSetResponse>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns0:RetrieveValueSetResponse xmlns:ns0="urn:ihe:iti:svs:2008" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <ns0:ValueSet ID="1.3.6.1.4.1.33895.1.3.0.45" displayName="Comfort Measures " version="MU2 Update 2015-05-01">
+        <ns0:ConceptList>
+            <ns0:Concept code="133918004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMEDCT" codeSystemVersion="2014-09" displayName="Comfort measures (regime/therapy)"/>
+            <ns0:Concept code="182964004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMEDCT" codeSystemVersion="2014-09" displayName="Terminal care (regime/therapy)"/>
+            <ns0:Concept code="385736008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMEDCT" codeSystemVersion="2014-09" displayName="Dying care (regime/therapy)"/>
+            <ns0:Concept code="385763009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMEDCT" codeSystemVersion="2014-09" displayName="Hospice care (regime/therapy)"/>
+        </ns0:ConceptList>
+    </ns0:ValueSet>
+</ns0:RetrieveValueSetResponse>

--- a/test/unit/models/svs/value_set_test.rb
+++ b/test/unit/models/svs/value_set_test.rb
@@ -5,7 +5,8 @@ class ValueSetTest < Minitest::Test
     doc = Nokogiri::XML(File.new('test/fixtures/value_sets/value_sets.xml'))
     vs = HealthDataStandards::SVS::ValueSet.load_from_xml(doc)
     assert_equal '1.3.6.1.4.1.33895.1.3.0.45', vs.oid
-    assert vs.concepts.any? {|c| c.code == "103735009"}
+    assert vs.concepts.any? {|c| c.code == "385763009"}
+    assert vs.concepts.any? {|c| c.code_system_version == '2014-09'}
   end
 
   def test_code_set_map
@@ -15,6 +16,6 @@ class ValueSetTest < Minitest::Test
     assert code_set_map
     assert_equal 1, code_set_map.length
     assert_equal code_set_map[0]['set'], 'SNOMED-CT'
-    assert_includes code_set_map[0]['values'], "103735009"
+    assert_includes code_set_map[0]['values'], "385763009"
   end
 end


### PR DESCRIPTION
From VSAC, the attribute defining the code system version comes back as `codeSystemVersion`, rather than `code_system_version`. 

Also updated `test/fixtures/value_sets/value_sets.xml` to the latest version from the VSAC API, as this gives us the most up-to-date format, which includes the code system version and allows us to test the code system version attribute. This required an update to the particular SNOMED code being checked in the two tests.
