### PR TITLE
Updated ValueSet API to V2, and added tests to test the new features/format

### DIFF
--- a/lib/health-data-standards/util/vs_api.rb
+++ b/lib/health-data-standards/util/vs_api.rb
@@ -2,10 +2,10 @@ require 'rest_client'
 require 'uri'
 module HealthDataStandards
   module Util
-  		class VSNotFoundError < StandardError
-  		end
+  	class VSNotFoundError < StandardError
+  	end
 
-		class VSApi			
+		class VSApi
 			attr_accessor :api_url, :ticket_url, :username, :password
 
 			def initialize(ticket_url, api_url, username, password)
@@ -15,7 +15,45 @@ module HealthDataStandards
 				@password = password
 			end
 
-			def get_valueset(oid, version=nil, include_draft=nil, &block)
+      def get_valueset(oid, effective_date=nil, include_draft=false, &block)
+				params = {id: oid, ticket: get_ticket}
+				params[:effectiveDate] = effective_date if effective_date
+				params[:includeDraft] = 'yes' if include_draft
+				vs = RestClient.get api_url, {:params=>params}
+				yield oid,vs if block_given?
+				vs
+			end
+
+			def process_valuesets(oids, effective_date=nil, &block)
+				oids.each do |oid|
+		    	vs = get_valueset(oid,effective_date)
+		    	yield oid,vs
+				end
+			end
+
+			def proxy_ticket
+			  @proxy_ticket ||= get_proxy_ticket
+			end
+
+			def get_proxy_ticket
+				# the content type is set and the body is a string becuase the NLM service does not support urlencoded content and
+				# throws an error on that contnet type
+				RestClient.post ticket_url, {username: username, password: password}
+			end
+
+			def get_ticket
+			  RestClient.post "#{ticket_url}/#{proxy_ticket}", {service: "http://umlsks.nlm.nih.gov"}
+		  end
+		end
+
+    class VSApiV2 < VSApi
+      def initialize(ticket_url, api_url, username, password)
+        super(ticket_url, api_url, username, password)
+      end
+
+      def get_valueset(oid, options = {}, &block)
+        version = options.fetch(:version, nil)
+        include_draft = options.fetch(:include_draft, false)
 				params = {id: oid, ticket: get_ticket}
 				params[:version] = version if version
 				params[:includeDraft] = 'yes' if include_draft
@@ -28,26 +66,14 @@ module HealthDataStandards
 				vs
 			end
 
-			def process_valuesets(oids, version=nil, &block)
+      def process_valuesets(oids, options = {}, &block)
+        version = options.fetch(:version, nil)
+        include_draft = options.fetch(:include_draft, false)
 				oids.each do |oid|
-		     		vs = get_valueset(oid,version)
-		     		yield oid,vs
+	        vs = get_valueset(oid, version: version, include_draft: include_draft)
+	    	  yield oid,vs
 				end
 			end
-
-			def proxy_ticket
-			 	@proxy_ticket ||= get_proxy_ticket
-			end
-
-			def get_proxy_ticket
-				# the content type is set and the body is a string becuase the NLM service does not support urlencoded content and
-				# throws an error on that contnet type
-				 RestClient.post ticket_url, {username: username, password: password}
-			end
-			
-			def get_ticket
-			  RestClient.post "#{ticket_url}/#{proxy_ticket}", {service: "http://umlsks.nlm.nih.gov"}
-		  end
-		end
+    end
   end
 end

--- a/test/unit/util/vs_api_test.rb
+++ b/test/unit/util/vs_api_test.rb
@@ -2,18 +2,21 @@ require 'test_helper'
 require 'webmock'
 class EntryTest < Minitest::Test
   include WebMock::API
+
+    def initialize(name = nil)
+        stub_request(:post,'https://localhost/token').with(:body =>{"password"=>"mypassword", "username"=>"myusername"}).to_return( :body=>"proxy_ticket")
+        stub_request(:post,'https://localhost/token/proxy_ticket').with(:body =>{"service"=>"http://umlsks.nlm.nih.gov"}).to_return( :body=>"ticket")
+        super(name)
+    end
   
 	def test_api
         valueset_xml_by_date = {}
         doc_ng = {}
         valueset_xml_version = {}
 
-        valueset_xml_by_date[:old] = "20101025"
-        valueset_xml_by_date[:new] = "20130401"
         valueset_xml_by_date[:none] = ""
-        stub_request(:post,'https://localhost/token').with(:body =>{"password"=>"mypassword", "username"=>"myusername"}).to_return( :body=>"proxy_ticket")
-        stub_request(:post,'https://localhost/token/proxy_ticket').with(:body =>{"service"=>"http://umlsks.nlm.nih.gov"}).to_return( :body=>"ticket")
-
+        valueset_xml_by_date[:version] = "MU2 Update 2015-05-01"
+        
         valueset_xml_by_date.each do |valueset_xml| 
             version = valueset_xml[1]
             valueset_xml_by_date[valueset_xml[0]] = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23" version="#{ version }"></ValueSet></RetrieveValueSetResponse>}
@@ -24,15 +27,6 @@ class EntryTest < Minitest::Test
             assert_equal "proxy_ticket", api.proxy_ticket
             assert_equal "ticket", api.get_ticket
 
-            unless valueset_xml_version[valueset_xml[0]] == ""
-                stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket", :effectiveDate=>valueset_xml_version[valueset_xml[0]]}).to_return(:body=>valueset_xml_by_date[valueset_xml[0]])
-                assert_equal valueset_xml_by_date[valueset_xml[0]], api.get_valueset("oid", valueset_xml_version[valueset_xml[0]])
-                api.get_valueset("oid", valueset_xml_version[valueset_xml[0]]) do |oid,vs|
-                    assert_equal "oid", oid
-                    assert_equal valueset_xml_by_date[valueset_xml[0]], vs
-                end
-            end
-
             if valueset_xml_version[valueset_xml[0]] == "" 
                 stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket"}).to_return(:body=>valueset_xml_by_date[valueset_xml[0]])
                 assert_equal valueset_xml_by_date[valueset_xml[0]], api.get_valueset("oid") 
@@ -42,6 +36,24 @@ class EntryTest < Minitest::Test
                 end
             end
 
+            if valueset_xml[0] == :version
+                stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket", :version=>valueset_xml_version[valueset_xml[0]]}).to_return(:body=>valueset_xml_by_date[valueset_xml[0]])
+                assert_equal valueset_xml_by_date[valueset_xml[0]], api.get_valueset("oid", valueset_xml_version[valueset_xml[0]]) 
+                api.get_valueset("oid", valueset_xml_version[valueset_xml[0]]) do |oid,vs|
+                    assert_equal "oid", oid
+                    assert_equal valueset_xml_by_date[valueset_xml[0]], vs
+                end
+            end
+
         end
 	end
+
+    def test_404_response
+        stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket"}).to_return(:status => 404, :headers => {:Warning => "111 NAV: Unknown value set"})
+        api = HealthDataStandards::Util::VSApi.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
+        assert_raises HealthDataStandards::Util::VSNotFoundError, "Doesn't raise proper exception for an unknown Valueset" do
+            api.get_valueset("oid")
+        end
+    end
+
 end

--- a/test/unit/util/vs_api_test.rb
+++ b/test/unit/util/vs_api_test.rb
@@ -3,57 +3,78 @@ require 'webmock'
 class EntryTest < Minitest::Test
   include WebMock::API
 
-    def initialize(name = nil)
-        stub_request(:post,'https://localhost/token').with(:body =>{"password"=>"mypassword", "username"=>"myusername"}).to_return( :body=>"proxy_ticket")
-        stub_request(:post,'https://localhost/token/proxy_ticket').with(:body =>{"service"=>"http://umlsks.nlm.nih.gov"}).to_return( :body=>"ticket")
-        super(name)
-    end
-  
-	def test_api
-        valueset_xml_by_date = {}
-        doc_ng = {}
-        valueset_xml_version = {}
+  def initialize(name = nil)
+    stub_request(:post,'https://localhost/token').with(:body =>{"password"=>"mypassword", "username"=>"myusername"}).to_return( :body=>"proxy_ticket")
+    stub_request(:post,'https://localhost/token/proxy_ticket').with(:body =>{"service"=>"http://umlsks.nlm.nih.gov"}).to_return( :body=>"ticket")
+    super(name)
+  end
 
-        valueset_xml_by_date[:none] = ""
-        valueset_xml_by_date[:version] = "MU2 Update 2015-05-01"
-        
-        valueset_xml_by_date.each do |valueset_xml| 
-            version = valueset_xml[1]
-            valueset_xml_by_date[valueset_xml[0]] = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23" version="#{ version }"></ValueSet></RetrieveValueSetResponse>}
-            doc_ng[valueset_xml[0]] = Nokogiri::XML(valueset_xml_by_date[valueset_xml[0]])
-            valueset_xml_version[valueset_xml[0]] = doc_ng[valueset_xml[0]].xpath("//nlm:RetrieveValueSetResponse//nlm:ValueSet/@version")[0].value
-            api = HealthDataStandards::Util::VSApi.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
-            
-            assert_equal "proxy_ticket", api.proxy_ticket
-            assert_equal "ticket", api.get_ticket
+  def test_api
+    valueset_xml_by_date = {}
+    doc_ng = {}
+    valueset_xml_version = {}
 
-            if valueset_xml_version[valueset_xml[0]] == "" 
-                stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket"}).to_return(:body=>valueset_xml_by_date[valueset_xml[0]])
-                assert_equal valueset_xml_by_date[valueset_xml[0]], api.get_valueset("oid") 
-                api.get_valueset("oid") do |oid,vs|
-                    assert_equal "oid", oid
-                    assert_equal valueset_xml_by_date[valueset_xml[0]], vs
-                end
-            end
+    valueset_xml_by_date[:old] = "20101025"
+    valueset_xml_by_date[:new] = "20130401"
+    valueset_xml_by_date[:none] = ""
 
-            if valueset_xml[0] == :version
-                stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket", :version=>valueset_xml_version[valueset_xml[0]]}).to_return(:body=>valueset_xml_by_date[valueset_xml[0]])
-                assert_equal valueset_xml_by_date[valueset_xml[0]], api.get_valueset("oid", valueset_xml_version[valueset_xml[0]]) 
-                api.get_valueset("oid", valueset_xml_version[valueset_xml[0]]) do |oid,vs|
-                    assert_equal "oid", oid
-                    assert_equal valueset_xml_by_date[valueset_xml[0]], vs
-                end
-            end
+    valueset_xml_by_date.each do |valueset_xml|
+      version = valueset_xml[1]
+      valueset_xml_by_date[valueset_xml[0]] = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23" version="#{ version }"></ValueSet></RetrieveValueSetResponse>}
+      doc_ng[valueset_xml[0]] = Nokogiri::XML(valueset_xml_by_date[valueset_xml[0]])
+      valueset_xml_version[valueset_xml[0]] = doc_ng[valueset_xml[0]].xpath("//nlm:RetrieveValueSetResponse//nlm:ValueSet/@version")[0].value
+      api = HealthDataStandards::Util::VSApi.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
 
+      assert_equal "proxy_ticket", api.proxy_ticket
+      assert_equal "ticket", api.get_ticket
+
+      unless valueset_xml_version[valueset_xml[0]] == ""
+        stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket", :effectiveDate=>valueset_xml_version[valueset_xml[0]]}).to_return(:body=>valueset_xml_by_date[valueset_xml[0]])
+        assert_equal valueset_xml_by_date[valueset_xml[0]], api.get_valueset("oid", valueset_xml_version[valueset_xml[0]])
+        api.get_valueset("oid", valueset_xml_version[valueset_xml[0]]) do |oid,vs|
+          assert_equal "oid", oid
+          assert_equal valueset_xml_by_date[valueset_xml[0]], vs
         end
+      end
+
+      if valueset_xml_version[valueset_xml[0]] == ""
+        stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket"}).to_return(:body=>valueset_xml_by_date[valueset_xml[0]])
+        assert_equal valueset_xml_by_date[valueset_xml[0]], api.get_valueset("oid")
+        api.get_valueset("oid") do |oid,vs|
+          assert_equal "oid", oid
+          assert_equal valueset_xml_by_date[valueset_xml[0]], vs
+        end
+      end
+    end
 	end
 
-    def test_404_response
-        stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket"}).to_return(:status => 404, :headers => {:Warning => "111 NAV: Unknown value set"})
-        api = HealthDataStandards::Util::VSApi.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
-        assert_raises HealthDataStandards::Util::VSNotFoundError, "Doesn't raise proper exception for an unknown Valueset" do
-            api.get_valueset("oid")
-        end
+  def test_api_v2_with_version
+    valueset_xml_version = "MU2 Update 2015-05-01"
+    valueset_xml = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23" version="#{ valueset_xml_version }"></ValueSet></RetrieveValueSetResponse>}
+    stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket" ,:version => valueset_xml_version}).to_return(:body=>valueset_xml)
+    api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
+    api.get_valueset("oid", version: valueset_xml_version) do |oid,vs|
+      assert_equal "oid", oid
+      assert_equal valueset_xml, vs
     end
+  end
+
+  def test_api_v2
+    valueset_xml = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23"></ValueSet></RetrieveValueSetResponse>}
+    stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket"}).to_return(:body=>valueset_xml)
+    api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
+    api.get_valueset("oid") do |oid, vs|
+      assert_equal "oid", oid
+      assert_equal valueset_xml, vs
+    end
+  end
+
+  def test_404_response
+    stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket"}).to_return(:status => 404, :headers => {:Warning => "111 NAV: Unknown value set"})
+    api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
+    assert_raises HealthDataStandards::Util::VSNotFoundError, "Doesn't raise proper exception for an unknown Valueset" do
+      api.get_valueset("oid")
+    end
+  end
 
 end


### PR DESCRIPTION
The new NLM VSAC API V2 is documented here: http://www.nlm.nih.gov/vsac/support/usingvsac/vsacsvsapiv2.html

Notable changes include:

`effectiveDate` in the `retrieveValueSet` endpoint has been removed in favor of `version`. In order to use `effectiveDate`, the `retrieveMultipleValueSets` endpoint would have to be used, and it has a different XML format than `retrieveValueSet`, and so would require other changes. This API rewrite is designed to be used with `retrieveValueSet`. There is also an API call to get valueset versions for a given OID, but that has not been implemented in Health Data Standards.

The response when no Value Set has been found for an OID has been changed from a status `200` to a `404`. As a result, we now capture the `ResourceNotFound` exception raised by `RestClient`, and throw our own, more descriptive `VSNotFoundError`.
