### PR TITLE
Fix hqmf specific occurrence issue

### DIFF
--- a/lib/hqmf-parser/2.0/data_criteria.rb
+++ b/lib/hqmf-parser/2.0/data_criteria.rb
@@ -348,7 +348,7 @@ module HQMF2
     def title
       dispValue = attr_val("#{@code_list_xpath}/cda:displayName/@value")
       # filter out occurrence prefix from titles
-      dispValue = dispValue.split(/Occurrence [A-Z]_/).try(:last) if dispValue
+      dispValue = dispValue.split(/Occurrence [A-Z]_/).last if dispValue
       @title || dispValue || @description || id # allow defined titles to take precedence
     end
 
@@ -625,7 +625,7 @@ module HQMF2
         strippedId = strip_tokens @id
         strippedLVN = strip_tokens @local_variable_name
         # remove any occurrence prefix(es) to resolve regex parsing issues
-        strippedSDC = strippedSDC.split(/#{occurrenceIdRegex}/).try(:last)
+        strippedSDC = strippedSDC.split(/#{occurrenceIdRegex}/).last
 
         # TODO: What should happen if neither @id or @lvn has occurrence label?
         # puts "Checking #{"#{occurrenceIdRegex}#{strippedSDC}"} against #{strippedId}"

--- a/lib/hqmf-parser/2.0/data_criteria.rb
+++ b/lib/hqmf-parser/2.0/data_criteria.rb
@@ -622,8 +622,10 @@ module HQMF2
         strippedSDC = strip_tokens @source_data_criteria
         strippedId = strip_tokens @id
         strippedLVN = strip_tokens @local_variable_name
+        # remove any occurrence prefix(es) to resolve regex parsing issues
+        strippedSDC = strippedSDC.split(/#{occurrenceIdRegex}/).try(:last)
 
-        # TODO: What should happen is neither @id or @lvn has occurrence label?
+        # TODO: What should happen if neither @id or @lvn has occurrence label?
         # puts "Checking #{"#{occurrenceIdRegex}#{strippedSDC}"} against #{strippedId}"
         # puts "Checking #{"#{occurrenceLVNRegex}#{strippedSDC}"} against #{strippedLVN}"
         if !(strippedId =~ /^#{occurrenceIdRegex}#{strippedSDC}/).nil?

--- a/lib/hqmf-parser/2.0/data_criteria.rb
+++ b/lib/hqmf-parser/2.0/data_criteria.rb
@@ -347,6 +347,8 @@ module HQMF2
     # @return [String] the title of this data criteria
     def title
       dispValue = attr_val("#{@code_list_xpath}/cda:displayName/@value")
+      # filter out occurrence prefix from titles
+      dispValue = dispValue.split(/Occurrence [A-Z]_/).try(:last) if dispValue
       @title || dispValue || @description || id # allow defined titles to take precedence
     end
 

--- a/lib/hqmf-parser/2.0/document.rb
+++ b/lib/hqmf-parser/2.0/document.rb
@@ -412,10 +412,11 @@ module HQMF2
         unless dc.source_data_criteria.split(/Occurrence[A-Z]_/).length > 1
           cloned_sdc = "Occurrence#{dc.specific_occurrence}_#{dc.source_data_criteria}"
           cloned_s_occr_const = dc.source_data_criteria.upcase
+        else
+          # otherwise use the supplied sdc and non-prefixed s_occr_const
+          cloned_sdc = dc.source_data_criteria
+          cloned_s_occr_const = dc.source_data_criteria.split(/Occurrence[A-Z]_/).last.try(:upcase)
         end
-        # by default we will use the supplied sdc and non-prefixed s_occr_const
-        cloned_sdc ||= dc.source_data_criteria
-        cloned_s_occr_const ||= dc.source_data_criteria.split(/Occurrence[A-Z]_/).try(:last).try(:upcase)
         # puts "Updated #{dc.id} SDC from #{dc.source_data_criteria} to #{cloned_sdc}"
         dc.patch_sdc_clone(nil, cloned_sdc, nil, cloned_s_occr_const)
       end

--- a/lib/hqmf-parser/2.0/document.rb
+++ b/lib/hqmf-parser/2.0/document.rb
@@ -408,9 +408,16 @@ module HQMF2
         next if sdc.try(:specific_occurrence) == dc.specific_occurrence
         specifics_map[dc.source_data_criteria] ||= []
         specifics_map[dc.source_data_criteria] << dc.specific_occurrence
-        cloned_sdc = "Occurrence#{dc.specific_occurrence}_#{dc.source_data_criteria}"
+        # only prefix occurrence identifier if it doesn't already exist
+        unless dc.source_data_criteria.split(/Occurrence[A-Z]_/).length > 1
+          cloned_sdc = "Occurrence#{dc.specific_occurrence}_#{dc.source_data_criteria}"
+          cloned_s_occr_const = dc.source_data_criteria.upcase
+        end
+        # by default we will use the supplied sdc and non-prefixed s_occr_const
+        cloned_sdc ||= dc.source_data_criteria
+        cloned_s_occr_const ||= dc.source_data_criteria.split(/Occurrence[A-Z]_/).try(:last).try(:upcase)
         # puts "Updated #{dc.id} SDC from #{dc.source_data_criteria} to #{cloned_sdc}"
-        dc.patch_sdc_clone(nil, cloned_sdc, nil, dc.source_data_criteria.upcase)
+        dc.patch_sdc_clone(nil, cloned_sdc, nil, cloned_s_occr_const)
       end
       specifics_map.each do |sdc_id, occurrences|
         existing = @data_criteria_references[sdc_id]


### PR DESCRIPTION
### Notes
- filter out `Occurrence A_` prefixes in data criteria titles
- fix bug with specific occurrence identifier extraction and duplicate `OccurrenceA_` prefixes
- prevent duplicate prefixes for data criteria `specific_occurrence_const` and `source_data_criteria` values
