### PR TITLE
HQMFv2 parser fixes and tests

### DIFF
--- a/lib/hqmf-parser/parser.rb
+++ b/lib/hqmf-parser/parser.rb
@@ -13,13 +13,13 @@ module HQMF
         HQMF2::Document.new(xml_contents).to_model
       end
 
-      def parse_fileds(xml_contents)
+      def parse_fields(xml_contents)
         result = {}
         doc = HQMF2::Document.parse(xml_contents)
         type = doc.at_xpath('/cda:QualityMeasureDocument/cda:code/@code').value
         if type == '57024-2'
           id = doc.at_xpath('cda:QualityMeasureDocument/cda:id/@extension', HQMF2::Document::NAMESPACES).value.upcase
-          set_id = doc.at_xpath('cda:QualityMeasureDocument/cda:setId/@extension').value.upcase
+          set_id = doc.at_xpath('cda:QualityMeasureDocument/cda:setId/@root').value.upcase
           version_number = doc.at_xpath('cda:QualityMeasureDocument/cda:versionNumber/@value').value.to_i
           title = doc.at_xpath('cda:QualityMeasureDocument/cda:title/@value').inner_text
           description = doc.at_xpath('cda:QualityMeasureDocument/cda:text/@value').inner_text

--- a/test/unit/hqmf/parser_test.rb
+++ b/test/unit/hqmf/parser_test.rb
@@ -21,4 +21,15 @@ class ParseTest < Test::Unit::TestCase
     parsed.title.must_equal "Statin Prescribed at Discharge"
   end
 
+  def test_parse_fields_v1
+    parsed_fields = HQMF::Parser::V1Parser.new.parse_fields(@hqmf_contents_v1)
+
+    parsed_fields['title'].must_equal "Pneumonia Vaccination Status for Older Adults (NQF 0043)"
+  end
+
+  def test_parse_fields_v2
+    parsed_fields = HQMF::Parser::V2Parser.new.parse_fields(@hqmf_contents_v2)
+
+    parsed_fields['title'].must_equal "Sample Quality Measure Document"
+  end
 end


### PR DESCRIPTION
- Fixed the name of the 'parse_fields' HQMFv2 parser method, as before it was 'parse_feilds'
- Changed the xpath of the setId statement to '@root' from '@extension', as apparently that's how HQMFv2 works
- Added tests for the parse_fields methods for both HQMFv1 and v2 to the parser unit test
