### PR TITLE
Cypress 27 updates

### DIFF
--- a/lib/health-data-standards/import/cat1/patient_importer.rb
+++ b/lib/health-data-standards/import/cat1/patient_importer.rb
@@ -56,7 +56,8 @@ module HealthDataStandards
                                           generate_importer(CDA::ResultImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.38']", '2.16.840.1.113883.3.560.1.5', 'performed'), #lab performed
                                           generate_importer(CDA::ResultImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']", '2.16.840.1.113883.3.560.1.47'), #intervention result
                                           generate_importer(CDA::ResultImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.57']", '2.16.840.1.113883.3.560.1.18'), #physical exam finding
-                                          generate_importer(CDA::ResultImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.28']", '2.16.840.1.113883.3.560.1.88'), #functional status result    
+                                          generate_importer(CDA::ResultImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.28']", '2.16.840.1.113883.3.560.1.88'), #functional status result  
+                                          generate_importer(CDA::ResultImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.26']", '2.16.840.1.113883.3.560.1.85'),  #functional status, performed
                                           generate_importer(LabResultImporter, nil, '2.16.840.1.113883.3.560.1.12')] #lab result
 
           @section_importers[:encounters] = [generate_importer(EncounterPerformedImporter, "./cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']", '2.16.840.1.113883.3.560.1.79', 'performed'), #encounter performed

--- a/lib/health-data-standards/validate/reported_result_extractor.rb
+++ b/lib/health-data-standards/validate/reported_result_extractor.rb
@@ -12,6 +12,7 @@ module ReportedResultExtractor
         results = nil
         _ids = ids.dup
         stratification = _ids.delete("stratification")
+        stratification ||= _ids.delete("STRAT")
         errors = []
         nodes = find_measure_node(measure_id, doc)
 

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.26.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.26.cat1.erb
@@ -1,0 +1,18 @@
+ <entry>
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- Functional Status, Performed template -->
+    <templateId root="2.16.840.1.113883.10.20.24.3.26"/>
+    <id root="1.3.6.1.4.1.115" extension="<%= entry.id %>"/>
+    <%== code_display(entry, 'value_set_map' => value_set_map, 'preferred_code_sets' => ['LOINC', 'SNOMED-CT', 'ICD-9-CM', 'ICD-10-CM'], 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
+    <text><%= entry.description %></text>
+    <statusCode code="completed"/>
+
+    <effectiveTime>
+      <low <%= value_or_null_flavor(entry.start_time) %>/>
+      <high <%= value_or_null_flavor(entry.end_time) %>/>
+    </effectiveTime>
+
+    <!-- Result -->
+    <%== render(:partial => 'result_value', :locals => {:values => [entry.values.first], :result_oids=>result_oids}) %>
+  </observation>
+</entry>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.32.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.32.cat1.erb
@@ -12,5 +12,9 @@
       <high <%= value_or_null_flavor(entry.end_time) %>/>
     </effectiveTime>
     <%== render(:partial => 'reason', :locals => {:entry => entry ,:reason_oids=>field_oids["REASON"]}) %>
+    <%if !entry.values.empty? %>
+      <%== render(:partial=> 'result_value', :locals => {:values => entry.values}) %>
+    <% end %>
+
   </act>
 </entry>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.38.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.38.cat1.erb
@@ -12,5 +12,9 @@
       <high <%= value_or_null_flavor(entry.end_time) %>/>
     </effectiveTime>
     <%== render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
-  </observation>
+
+    <%if !entry.values.empty? %>
+      <%== render(:partial=> 'result_value', :locals => {:values => entry.values}) %>
+    <% end %>
+    </observation>
 </entry>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.64.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.64.cat1.erb
@@ -27,6 +27,26 @@
       </procedure>
     </entryRelationship>
     <% end -%>
+
+    <% entry.values.each do |value| %>
+      <entryRelationship typeCode="REFR">
+       <observation classCode="OBS" moodCode="EVN">
+         <!-- Conforms to C-CDA R2 Result Observation (V2) -->
+         <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+         <!-- Result (QRDA I R3) -->
+         <templateId root="2.16.840.1.113883.10.20.24.3.87" />
+         <id root="1.3.6.1.4.1.115" extension="<%= identifier_for(value) %>"/>
+          <%== code_display(entry, 'value_set_map' => value_set_map, 'preferred_code_sets' => ['LOINC', 'SNOMED-CT', 'CPT', 'ICD-9-PCS', 'ICD-10-PCS'], 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
+          <statusCode code="completed"/>
+          <effectiveTime>
+            <low <%= value_or_null_flavor(entry.start_time) %>/>
+            <high <%= value_or_null_flavor(entry.end_time) %>/>
+          </effectiveTime>
+         <%== render(:partial=> 'result_value', :locals => {:values => [value]}) %>
+        
+       </observation>
+     </entryRelationship>
+   <% end %>
   </procedure>
 </entry>
 


### PR DESCRIPTION
- Updated a number of templates, primarily to display results in "<x>, performed" templates
- Updated the patient importer to add an importer for results values to "<x>, performed" cat 1 importing
- Added code to the section importer to get _all_ the result values, not just the first one, when the result values are in their own `observation`
- Changed the reported result extractor to import stratified results from `STRAT` in addition to `stratification`
