### PR TITLE
Performance rate rounding

### DIFF
--- a/lib/health-data-standards/validate/performance_rate_validator.rb
+++ b/lib/health-data-standards/validate/performance_rate_validator.rb
@@ -76,7 +76,7 @@ module HealthDataStandards
         else
           if (reported_result['PR']['value'].split('.',2).last.size > 6)
             return build_error("Reported Performance Rate SHALL not have a precision greater than .000001 ", "/", data[:file_name])
-          elsif (reported_result['PR']['value'].to_f - expected.to_s[0,8].to_f).abs > 0.0000001
+          elsif (reported_result['PR']['value'].to_f - expected.round(6)).abs > 0.0000001
             return build_error("Reported Performance Rate of #{reported_result['PR']['value']} for Numerator #{_ids['NUMER']} does not match expected value of #{expected.to_s[0,8]}.", "/", data[:file_name])
           end
         end

--- a/templates/cat3/_performance_rate.cat3.erb
+++ b/templates/cat3/_performance_rate.cat3.erb
@@ -5,7 +5,7 @@
     codeSystemName="2.16.840.1.113883.6.1"/>
   <statusCode code="completed"/>
   <% if population_group.performance_rate_denominator > 0 %>
-  <value xsi:type="REAL" value="<%= population_group.performance_rate %>"/>
+  <value xsi:type="REAL" value="<%= population_group.performance_rate.round(6) %>"/>
   <% else %>
     <value xsi:type="REAL" nullFlavor="NA"/>
   <% end %>

--- a/test/unit/validate/performance_rate_validator_test.rb
+++ b/test/unit/validate/performance_rate_validator_test.rb
@@ -163,4 +163,21 @@ class PerformanceRateValidatorTest < ActiveSupport::TestCase
     assert_equal 1, errorsList.length
   end
 
+  test "Performance Rate equals .571429 reported .571428" do
+    errorsList = []
+    population_ids = {}
+    population_ids['NUMER'] = "test_numer"
+    reported_result = {}
+    reported_result['DENOM'] = 7
+    reported_result['DENEX'] = 0
+    reported_result['DENEXCEP'] = 0
+    reported_result['NUMER'] = 4
+    reported_result['PR'] = {}
+    reported_result['PR']['value'] = ".571428"
+    errors = @prcat3.check_performance_rates(reported_result, population_ids,nil,file_name: "test")
+    errorsList << errors
+    #1 incorrect performance rates
+    assert_equal 1, errorsList.length
+  end
+
 end


### PR DESCRIPTION
Round the expected performance rate number to 6 decimal places when:
- Using it in a cat3 template
- Comparing it to the reported number in the `performance_rate_validator`
