### PR TITLE
HTML template update backports from master

### DIFF
--- a/lib/health-data-standards/export/view_helper.rb
+++ b/lib/health-data-standards/export/view_helper.rb
@@ -75,6 +75,13 @@ module HealthDataStandards
       end
       
       def convert_field_to_hash(field, codes)
+<<<<<<< HEAD
+=======
+        if codes.is_a? Array
+          return codes.collect{ |code| convert_field_to_hash(field, convert_field_to_hash(field, code))}.join("<br>")
+        end
+
+>>>>>>> f9f49b9... Updated the view_helper and _entry template to facilitate arrays of fulfillment histories for CMD
         if (codes.is_a? Hash)
           clean_hash = {}
           

--- a/lib/health-data-standards/export/view_helper.rb
+++ b/lib/health-data-standards/export/view_helper.rb
@@ -126,7 +126,13 @@ module HealthDataStandards
           elsif codes['scalar']
             return "#{codes['scalar']} #{codes['units']}"
           else
-            return codes.map {|hashcode_set, hashcodes| "#{hashcode_set}: #{(hashcodes.respond_to? :join) ? hashcodes.join(', ') : hashcodes.to_s}"}.join(' ')
+            return codes.map do |hashcode_set, hashcodes| 
+              if hashcodes.is_a? Hash
+                "#{hashcode_set}: #{convert_field_to_hash(hashcode_set, hashcodes)}"
+              else
+                "#{hashcode_set}: #{(hashcodes.respond_to? :join) ? hashcodes.join(', ') : hashcodes.to_s}"
+              end
+            end.join(' ')
           end
             
           clean_hash

--- a/lib/health-data-standards/export/view_helper.rb
+++ b/lib/health-data-standards/export/view_helper.rb
@@ -131,7 +131,7 @@ module HealthDataStandards
             
           clean_hash
         else
-          if codes && (field.match(/Time$/) || field.match(/\_time$/)) 
+          if codes && (field.match(/Time$/) || field.match(/\_time$/) || field.match(/Date$/)) 
             Entry.time_to_s(codes)
           else
             codes.to_s

--- a/lib/health-data-standards/export/view_helper.rb
+++ b/lib/health-data-standards/export/view_helper.rb
@@ -49,6 +49,14 @@ module HealthDataStandards
         end
       end
 
+      def fulfillment_quantity(codes, fulfillmentHistory, dose)
+        if (codes["RxNorm"].present?)
+          doses = (fulfillmentHistory.quantity_dispensed['value'].to_f / dose['value'].to_f ).to_i
+          return "value='#{doses}'"
+        else
+          return "value='#{fulfillmentHistory.quantity_dispensed['value']}' unit='#{fulfillmentHistory.quantity_dispensed['unit']}'"
+        end
+      end
            
       def value_or_null_flavor(time)
         if time 

--- a/lib/health-data-standards/export/view_helper.rb
+++ b/lib/health-data-standards/export/view_helper.rb
@@ -66,6 +66,14 @@ module HealthDataStandards
        end
       end
 
+      def dose_quantity(codes, dose)
+        if (codes["RxNorm"].present?)
+          return "value='1'"
+        else
+          return "value=#{dose['value']} unit=#{dose['unit']}" 
+        end
+      end
+
       def time_if_not_nil(*args)
         args.compact.map {|t| Time.at(t).utc}.first
       end
@@ -83,13 +91,11 @@ module HealthDataStandards
       end
       
       def convert_field_to_hash(field, codes)
-<<<<<<< HEAD
-=======
+
         if codes.is_a? Array
           return codes.collect{ |code| convert_field_to_hash(field, convert_field_to_hash(field, code))}.join("<br>")
         end
 
->>>>>>> f9f49b9... Updated the view_helper and _entry template to facilitate arrays of fulfillment histories for CMD
         if (codes.is_a? Hash)
           clean_hash = {}
           

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.41.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.41.cat1.erb
@@ -34,5 +34,31 @@
       </manufacturedProduct>
     </consumable>
     <%== render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
+
+    <% if entry.fulfillmentHistory.present?
+    fulfillmentHistory = entry.fulfillmentHistory[0] %>
+    <entryRelationship>
+      <supply classCode="SPLY" moodCode="EVN">
+        <!-- Medication Dispense template -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.18"/>
+        <id root="1.3.6.1.4.1.115" extension="<%= UUID.generate %>"/>
+        <statusCode code="completed"/>
+        <effectiveTime <%= value_or_null_flavor(fulfillmentHistory.dispense_date) %>/>
+        <repeatNumber value="1"/>
+        <quantity <%= fulfillment_quantity(entry.codes, fulfillmentHistory, entry.dose) %>/>
+        <product>
+          <manufacturedProduct classCode="MANU">
+            <!-- Medication Information (consolidation) template -->
+            <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+            <id root="<%= UUID.generate %>"/>
+            <manufacturedMaterial>
+              <%== code_display(entry, 'preferred_code_sets' =>["RxNorm"], 'value_set_map' => value_set_map, 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
+            </manufacturedMaterial>
+          </manufacturedProduct>
+        </product>
+      </supply>
+    </entryRelationship>
+  <% end %>
   </substanceAdministration>
+
 </entry>

--- a/templates/cat1/_medication_details.cat1.erb
+++ b/templates/cat1/_medication_details.cat1.erb
@@ -11,5 +11,5 @@
 <% end -%>
 
 <% if entry.respond_to?(:dose) && entry.dose.present? -%>
-<doseQuantity value="<%= entry.dose['value']%>"/>
+<doseQuantity <%= dose_quantity(entry.codes, entry.dose) %>/>
 <% end -%>

--- a/templates/html/_entry.html.erb
+++ b/templates/html/_entry.html.erb
@@ -44,17 +44,16 @@
 	  <% 
 	    (entry.attributes.keys.reject {|key| ['codes', 'time', 'description', 'mood_code', 'values', '_id', '_type', 'start_time', 'end_time', 'status_code', 'negationInd', 'oid'].include? key}).sort.each do |field|
       field_value = convert_field_to_hash(field, entry.attributes[field])
-
     %>
         <% if field_value && !field_value.empty? %> 
         <dl>
           <% if field_value.is_a? Hash %>
             <dt><b><%= field.titleize %>:</b></dt>
 	          <% field_value.keys.sort.reverse.each do |fieldkey| %>
-	            <dd><%= fieldkey %>: <i><%= field_value[fieldkey] %></i></dd>
+                    <dd><%= fieldkey %>: <i><%== field_value[fieldkey] %></i></dd>
 	          <% end %>
           <% else %>
-            <dt><b><%= field.titleize %></b>: <%= field_value%></dt>
+            <dt><b><%= field.titleize %></b>: <%== field_value%></dt>
           <% end %>
         <dl>
         <% end %>


### PR DESCRIPTION
A couple of things needed to make their way into the `bonnie_master` branch of Health-Data-Standards in order for HTML export of patients with medication fulfillment records to occur in a reader-friendly fashion. This cherry-picks those changes off of `master` and brings them into `bonnie_master`.
