### PR TITLE
Return performance rate validation to not rounding expected values

### DIFF
--- a/lib/health-data-standards/validate/performance_rate_validator.rb
+++ b/lib/health-data-standards/validate/performance_rate_validator.rb
@@ -76,7 +76,9 @@ module HealthDataStandards
         else
           if (reported_result['PR']['value'].split('.',2).last.size > 6)
             return build_error("Reported Performance Rate SHALL not have a precision greater than .000001 ", "/", data[:file_name])
-          elsif (reported_result['PR']['value'].to_f - expected.round(6)).abs > 0.0000001
+          #so the reason we're not just rounding the expected value to 6 decimal places is
+          #the performance rate is supposed to be unrounded; IE 2/3 should become 0.666666 not 0.666667
+          elsif (reported_result['PR']['value'].to_f - expected.to_s[0,8].to_f).abs > 0.0000001
             return build_error("Reported Performance Rate of #{reported_result['PR']['value']} for Numerator #{_ids['NUMER']} does not match expected value of #{expected.to_s[0,8]}.", "/", data[:file_name])
           end
         end

--- a/test/unit/validate/performance_rate_validator_test.rb
+++ b/test/unit/validate/performance_rate_validator_test.rb
@@ -180,4 +180,36 @@ class PerformanceRateValidatorTest < ActiveSupport::TestCase
     assert_equal 1, errorsList.length
   end
 
+  test "Performance Rate equals .666666 reported .666666" do
+    errorsList = []
+    population_ids = {}
+    population_ids['NUMER'] = "test_numer"
+    reported_result = {}
+    reported_result['DENOM'] = 6
+    reported_result['DENEX'] = 0
+    reported_result['DENEXCEP'] = 0
+    reported_result['NUMER'] = 4
+    reported_result['PR'] = {}
+    reported_result['PR']['value'] = ".666666"
+    errors = @prcat3.check_performance_rates(reported_result, population_ids,nil,file_name: "test")
+    assert_equal nil, errors
+  end
+
+  test "Performance Rate equals .666666 reported .666667" do
+    errorsList = []
+    population_ids = {}
+    population_ids['NUMER'] = "test_numer"
+    reported_result = {}
+    reported_result['DENOM'] = 6
+    reported_result['DENEX'] = 0
+    reported_result['DENEXCEP'] = 0
+    reported_result['NUMER'] = 4
+    reported_result['PR'] = {}
+    reported_result['PR']['value'] = ".666667"
+    errors = @prcat3.check_performance_rates(reported_result, population_ids,nil,file_name: "test")
+    errorsList << errors
+    #1 incorrect performance rates
+    assert_equal 1, errorsList.length
+  end
+
 end


### PR DESCRIPTION
Problem: Performance Rates (according to the spec) should NOT be rounded to 6 decimal places, but rather truncated. HDS's Performance Rate Valdiator was changed to round them in a previous pull request.

Solution: Change the code back to the way it was before that pull request, and add comments to the performance rate valdiator talking about why we're not rounding the performance rate validator. Also, add tests to ensure that we're correctly validating repeating decimals such as 2/3
