### PR TITLE
Xml export

### DIFF
--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.59.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.59.cat1.erb
@@ -1,6 +1,6 @@
-<% vals = entry.values.empty? ? [nil] : entry.values 
-   vals.each do |value| 
- %>   
+<% vals = entry.values.empty? ? [nil] : entry.values
+   vals.each do |value|
+ %>
 <entry>
   <observation classCode="OBS" moodCode="EVN" <%== negation_indicator(entry) %>>
     <!-- Procedure Activity Procedure (Consolidation) template -->
@@ -16,6 +16,7 @@
       <high <%= value_or_null_flavor(entry.end_time) %>/>
     </effectiveTime>
     <%== render(:partial => 'result_value', :locals => {:values => [value], :result_oids=>result_oids}) %>
+    <%== render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
   </observation>
 </entry>
 <% end %>

--- a/templates/cat1/_reason.cat1.erb
+++ b/templates/cat1/_reason.cat1.erb
@@ -4,7 +4,7 @@
       reason = entry.reason
     end
     
-    if reason
+    if reason.present?
       vset = oid_for_code(reason,reason_oids, entry.record["bundle_id"])
   -%>
 <entryRelationship typeCode="RSON">

--- a/templates/cat1/_reason.cat1.erb
+++ b/templates/cat1/_reason.cat1.erb
@@ -1,22 +1,31 @@
-<% if entry.negation_reason.present? 
-      vset = oid_for_code(entry.negation_reason,reason_oids, entry.record["bundle_id"])
+<%  if entry.negation_reason.present?
+      reason = entry.negation_reason
+    elsif entry.reason.present?
+      reason = entry.reason
+    end
+    
+    if reason
+      vset = oid_for_code(reason,reason_oids, entry.record["bundle_id"])
   -%>
 <entryRelationship typeCode="RSON">
   <observation classCode="OBS" moodCode="EVN">
-    <templateId root="2.16.840.1.113883.10.20.24.3.88"/>  
-    <id extension="<%= identifier_for([entry.negation_reason, entry.start_time]) %>" />
-    <code code="410666004" 
+    <templateId root="2.16.840.1.113883.10.20.24.3.88"/>
+    <id extension="<%= identifier_for([reason, entry.start_time]) %>" />
+    <code code="410666004"
           codeSystem="2.16.840.1.113883.6.96"
-          displayName="reason" 
+          displayName="reason"
           codeSystemName="SNOMED CT"/>
     <statusCode code="completed"/>
     <effectiveTime <%= value_or_null_flavor(entry.start_time) %>/>
-    <value xsi:type="CD" 
-         code="<%= entry.negation_reason['code'] %>" 
-         codeSystem="<%= HealthDataStandards::Util::CodeSystemHelper.oid_for_code_system(entry.negation_reason['codeSystem'] || entry.negation_reason['code_system']) %>"
-        <% if vset -%>
-          sdtc:valueSet="<%= vset %>"
-        <% end -%>
+    <value xsi:type="CD"
+         code="<%= reason['code'] %>"
+         codeSystem="<%= HealthDataStandards::Util::CodeSystemHelper.oid_for_code_system(reason['codeSystem'] || reason['code_system']) %>"
+       <% if reason.has_key?('title') -%>
+         displayName="<%=reason['title']%>"
+       <% end -%>
+       <% if vset -%>
+         sdtc:valueSet="<%= vset %>"
+       <% end -%>
          />
   </observation>
 </entryRelationship>


### PR DESCRIPTION
Bug fix for https://jira.oncprojectracking.org/browse/BONNIE-100.

The reason template only got processed for negation reasons, not for all reasons. According to the QRDA guidance, the template should be used for all reasons. Modified the template to work for both `item.reason` and `item.negation_reason`.

Additionally, found that the Procedure Physical Exam template was not exporting associated reasons. According to the QRDA documentation, it should. Added reason to the template.
