### PR TITLE
bug fix: severity code now shows a value. Value wasn't being displaye…

### DIFF
--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.11.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.11.cat1.erb
@@ -46,7 +46,14 @@
           <code code="SEV" 
                 codeSystem="2.16.840.1.113883.5.4"/>
            <statusCode code="completed"/>
-          <%== render(:partial => 'result_value', :locals => {:values => [entry.severity], :result_oids=>field_oids["SEVERITY"]} ) %>   
+           <value xsi:type="CD"
+                code="<%= entry.severity['code'] %>"
+                codeSystem="<%= HealthDataStandards::Util::CodeSystemHelper.oid_for_code_system(entry.severity['codeSystem'] || entry.severity['code_system']) %>"
+              <% if entry.severity.has_key?('title') -%>
+                displayName="<%=entry.severity['title']%>"
+              <% end -%>
+                sdtc:valueSet="<%= field_oids['SEVERITY'][0] %>"
+            />
        </observation>
 
     </entryRelationship>


### PR DESCRIPTION
Bug fix for https://jira.oncprojectracking.org/browse/BONNIE-95.

The [problem observation diagnosis active template](https://github.com/projectcypress/health-data-standards/blob/002b4621ade7f322647c4ebc7c6e1698eaa2229a/templates/cat1/_2.16.840.1.113883.10.20.24.3.11.cat1.erb) was calling the [result_value template](https://github.com/projectcypress/health-data-standards/blob/master/templates/cat1/_result_value.cat1.erb) with argument `entry.severity` to render the severity codes. However, the result_value template appears to expect arguments of type `ResultValue`.  `entry.severity` is a BSON document. Consequently, the result_value template does not appear to be the appropriate template for showing the severity value.

To fix the issue, I copied how the [reason template](https://github.com/projectcypress/health-data-standards/blob/master/templates/cat1/_reason.cat1.erb) rendered its code value.
