### PR TITLE
Made _reason template work with both objects and hashes

### DIFF
--- a/templates/cat1/_reason.cat1.erb
+++ b/templates/cat1/_reason.cat1.erb
@@ -20,7 +20,7 @@
     <value xsi:type="CD"
          code="<%= reason['code'] %>"
          codeSystem="<%= HealthDataStandards::Util::CodeSystemHelper.oid_for_code_system(reason['codeSystem'] || reason['code_system']) %>"
-       <% if reason.has_key?('title') -%>
+       <% if reason.respond_to?('title') || reason.has_key?('title') -%>
          displayName="<%=reason['title']%>"
        <% end -%>
        <% if vset -%>


### PR DESCRIPTION
JIRA: https://jira.oncprojectracking.org/browse/BONNIE-113

This was caused by an `Entry` object being passed into the `_reason.cat1.erb` template. `_reason.cat1.erb` expects a hash (it calls the `has_key?` method). Made `_reason.cat1.erb` able to handle both objects and hashes.
