### PR TITLE
Fix for issue with specific occurrences

### DIFF
--- a/lib/hqmf-parser/2.0/document.rb
+++ b/lib/hqmf-parser/2.0/document.rb
@@ -258,7 +258,7 @@ module HQMF2
         criteria.instance_variable_set(:@source_data_criteria, collapsed_source_data_criteria[criteria.id])
       end
       handle_variable(criteria) if criteria.variable
-
+      handle_specific_source_data_criteria_reference(criteria)
       @reference_ids.concat(criteria.children_criteria)
       if criteria.temporal_references
         criteria.temporal_references.each do |tr|
@@ -266,5 +266,16 @@ module HQMF2
         end
       end
     end
+    
+    # For specific occurrence data criteria, make sure the source data criteria reference points
+    # to the correct source data criteria.
+    def handle_specific_source_data_criteria_reference(criteria)
+      sdc = find(@source_data_criteria, :id, criteria.source_data_criteria)
+      if criteria && !criteria.specific_occurrence.nil? && !sdc.nil? && 
+          sdc.specific_occurrence.nil? && !find(@source_data_criteria, :id, criteria.id).nil?
+        criteria.instance_variable_set(:@source_data_criteria, criteria.id)
+      end
+    end
+    
   end
 end


### PR DESCRIPTION
The HQMF parser now makes sure specific occurrence data criteria have the correct source data criteria reference (to bring the parsed HQMF in line with the parsed SimpleXML).

Addresses BONNIE-122 as well as a Bonnie calculation bug caused by the parsed HQMF.
