### PR TITLE
Added support for VSAC APIv2's RetrieveMultipleValueSets calls.

### DIFF
--- a/lib/health-data-standards/models/svs/value_set.rb
+++ b/lib/health-data-standards/models/svs/value_set.rb
@@ -37,7 +37,7 @@ module HealthDataStandards
 
       def self.load_from_xml(doc)
         doc.root.add_namespace_definition("vs","urn:ihe:iti:svs:2008")
-        vs_element = doc.at_xpath("/vs:RetrieveValueSetResponse/vs:ValueSet")
+        vs_element = doc.at_xpath("/vs:RetrieveValueSetResponse/vs:ValueSet|/vs:RetrieveMultipleValueSetsResponse/vs:DescribedValueSet")
         if vs_element
           vs = ValueSet.new(oid: vs_element["ID"], display_name: vs_element["displayName"], version: vs_element["version"])
           concepts = vs_element.xpath("//vs:Concept").collect do |con|

--- a/lib/health-data-standards/util/vs_api.rb
+++ b/lib/health-data-standards/util/vs_api.rb
@@ -54,9 +54,11 @@ module HealthDataStandards
       def get_valueset(oid, options = {}, &block)
         version = options.fetch(:version, nil)
         include_draft = options.fetch(:include_draft, false)
+        effective_date = options.fetch(:effective_date, nil)
 				params = {id: oid, ticket: get_ticket}
 				params[:version] = version if version
 				params[:includeDraft] = 'yes' if include_draft
+        params[:effectiveDate] = effective_date if effective_date
 				begin
 					vs = RestClient.get api_url, {:params=>params}
 				rescue RestClient::ResourceNotFound


### PR DESCRIPTION
Adds an 'OR' to the XPath search for the valueset so the /RetrieveMultipleValueSets calls can be used. These calls have the effectiveDate parameter working.
