### PR TITLE
Added ticket_granting_ticket param to VSAC api

### DIFF
--- a/lib/health-data-standards/util/vs_api.rb
+++ b/lib/health-data-standards/util/vs_api.rb
@@ -8,11 +8,12 @@ module HealthDataStandards
 		class VSApi
 			attr_accessor :api_url, :ticket_url, :username, :password
 
-			def initialize(ticket_url, api_url, username, password)
+			def initialize(ticket_url, api_url, username, password, tgt=nil)
 				@api_url = api_url
 				@ticket_url = ticket_url
 				@username = username
 				@password = password
+        @proxy_ticket = tgt
 			end
 
       def get_valueset(oid, effective_date=nil, include_draft=false, &block)
@@ -38,17 +39,21 @@ module HealthDataStandards
 			def get_proxy_ticket
 				# the content type is set and the body is a string becuase the NLM service does not support urlencoded content and
 				# throws an error on that contnet type
-				RestClient.post ticket_url, {username: username, password: password}
+				RestClient.post @ticket_url, {username: @username, password: @password}
 			end
 
 			def get_ticket
 			  RestClient.post "#{ticket_url}/#{proxy_ticket}", {service: "http://umlsks.nlm.nih.gov"}
 		  end
+      
+      def self.get_tgt_using_credentials(username, password, ticket_url)        
+        RestClient.post ticket_url, {username: username, password: password}
+      end
 		end
 
     class VSApiV2 < VSApi
-      def initialize(ticket_url, api_url, username, password)
-        super(ticket_url, api_url, username, password)
+      def initialize(ticket_url, api_url, username, password, tgt=nil)
+        super(ticket_url, api_url, username, password, tgt)
       end
 
       def get_valueset(oid, options = {}, &block)

--- a/lib/health-data-standards/util/vs_api.rb
+++ b/lib/health-data-standards/util/vs_api.rb
@@ -2,57 +2,57 @@ require 'rest_client'
 require 'uri'
 module HealthDataStandards
   module Util
-  	class VSNotFoundError < StandardError
-  	end
+    class VSNotFoundError < StandardError
+    end
 
-		class VSApi
-			attr_accessor :api_url, :ticket_url, :username, :password
+    class VSApi
+      attr_accessor :api_url, :ticket_url, :username, :password
 
-			def initialize(ticket_url, api_url, username, password, ticket_granting_ticket=nil)
-				@api_url = api_url
-				@ticket_url = ticket_url
-				@username = username
-				@password = password
+      def initialize(ticket_url, api_url, username, password, ticket_granting_ticket = nil)
+        @api_url = api_url
+        @ticket_url = ticket_url
+        @username = username
+        @password = password
         @proxy_ticket = ticket_granting_ticket
-			end
-
-      def get_valueset(oid, effective_date=nil, include_draft=false, &block)
-				params = {id: oid, ticket: get_ticket}
-				params[:effectiveDate] = effective_date if effective_date
-				params[:includeDraft] = 'yes' if include_draft
-				vs = RestClient.get api_url, {:params=>params}
-				yield oid,vs if block_given?
-				vs
-			end
-
-			def process_valuesets(oids, effective_date=nil, &block)
-				oids.each do |oid|
-		    	vs = get_valueset(oid,effective_date)
-		    	yield oid,vs
-				end
-			end
-
-			def proxy_ticket
-			  @proxy_ticket ||= get_proxy_ticket
-			end
-
-			def get_proxy_ticket
-				# the content type is set and the body is a string becuase the NLM service does not support urlencoded content and
-				# throws an error on that contnet type
-				RestClient.post @ticket_url, {username: @username, password: @password}
-			end
-
-			def get_ticket
-			  RestClient.post "#{ticket_url}/#{proxy_ticket}", {service: "http://umlsks.nlm.nih.gov"}
-		  end
-      
-      def self.get_tgt_using_credentials(username, password, ticket_url)        
-        RestClient.post ticket_url, {username: username, password: password}
       end
-		end
+
+      def get_valueset(oid, effective_date = nil, include_draft = false, &block)
+        params = { id: oid, ticket: get_ticket }
+        params[:effectiveDate] = effective_date if effective_date
+        params[:includeDraft] = 'yes' if include_draft
+        vs = RestClient.get(api_url, params: params)
+        yield oid, vs if block_given?
+        vs
+      end
+
+      def process_valuesets(oids, effective_date = nil, &block)
+        oids.each do |oid|
+          vs = get_valueset(oid,effective_date)
+          yield oid,vs
+        end
+      end
+
+      def proxy_ticket
+        @proxy_ticket ||= get_proxy_ticket
+      end
+
+      def get_proxy_ticket
+        # the content type is set and the body is a string becuase the NLM service does not support urlencoded content and
+        # throws an error on that contnet type
+        RestClient.post(@ticket_url, username: @username, password: @password)
+      end
+
+      def get_ticket
+        RestClient.post("#{ticket_url}/#{proxy_ticket}", service: "http://umlsks.nlm.nih.gov")
+      end
+
+      def self.get_tgt_using_credentials(username, password, ticket_url)
+        RestClient.post(ticket_url, username: username, password: password)
+      end
+    end
 
     class VSApiV2 < VSApi
-      def initialize(ticket_url, api_url, username, password, ticket_granting_ticket=nil)
+      def initialize(ticket_url, api_url, username, password, ticket_granting_ticket = nil)
         super(ticket_url, api_url, username, password, ticket_granting_ticket)
       end
 
@@ -60,27 +60,27 @@ module HealthDataStandards
         version = options.fetch(:version, nil)
         include_draft = options.fetch(:include_draft, false)
         effective_date = options.fetch(:effective_date, nil)
-				params = {id: oid, ticket: get_ticket}
-				params[:version] = version if version
-				params[:includeDraft] = 'yes' if include_draft
+        params = { id: oid, ticket: get_ticket }
+        params[:version] = version if version
+        params[:includeDraft] = 'yes' if include_draft
         params[:effectiveDate] = effective_date if effective_date
-				begin
-					vs = RestClient.get api_url, {:params=>params}
-				rescue RestClient::ResourceNotFound
-					raise VSNotFoundError, "No ValueSet found for oid '#{oid}'"
-				end
-				yield oid,vs if block_given?
-				vs
-			end
+        begin
+          vs = RestClient.get(api_url, :params=>params)
+        rescue RestClient::ResourceNotFound
+          raise VSNotFoundError, "No ValueSet found for oid '#{oid}'"
+        end
+        yield oid, vs if block_given?
+        vs
+      end
 
       def process_valuesets(oids, options = {}, &block)
         version = options.fetch(:version, nil)
         include_draft = options.fetch(:include_draft, false)
-				oids.each do |oid|
-	        vs = get_valueset(oid, version: version, include_draft: include_draft)
-	    	  yield oid,vs
-				end
-			end
+        oids.each do |oid|
+          vs = get_valueset(oid, version: version, include_draft: include_draft)
+          yield oid, vs
+        end
+      end
     end
   end
 end

--- a/lib/health-data-standards/util/vs_api.rb
+++ b/lib/health-data-standards/util/vs_api.rb
@@ -8,12 +8,12 @@ module HealthDataStandards
 		class VSApi
 			attr_accessor :api_url, :ticket_url, :username, :password
 
-			def initialize(ticket_url, api_url, username, password, tgt=nil)
+			def initialize(ticket_url, api_url, username, password, ticket_granting_ticket=nil)
 				@api_url = api_url
 				@ticket_url = ticket_url
 				@username = username
 				@password = password
-        @proxy_ticket = tgt
+        @proxy_ticket = ticket_granting_ticket
 			end
 
       def get_valueset(oid, effective_date=nil, include_draft=false, &block)
@@ -52,8 +52,8 @@ module HealthDataStandards
 		end
 
     class VSApiV2 < VSApi
-      def initialize(ticket_url, api_url, username, password, tgt=nil)
-        super(ticket_url, api_url, username, password, tgt)
+      def initialize(ticket_url, api_url, username, password, ticket_granting_ticket=nil)
+        super(ticket_url, api_url, username, password, ticket_granting_ticket)
       end
 
       def get_valueset(oid, options = {}, &block)


### PR DESCRIPTION
When initializing a VSApi or VSApiV2 object, a ticket granting ticket can now optionally be specified, which will be used to retrieve service tickets for all VSAC API calls (as opposed to requesting a new tgt every single time an API call is made).
