### PR TITLE
adjusted sdc reference check for specific occurrences

### DIFF
--- a/lib/hqmf-parser/2.0/document.rb
+++ b/lib/hqmf-parser/2.0/document.rb
@@ -270,9 +270,10 @@ module HQMF2
     # For specific occurrence data criteria, make sure the source data criteria reference points
     # to the correct source data criteria.
     def handle_specific_source_data_criteria_reference(criteria)
-      sdc = find(@source_data_criteria, :id, criteria.source_data_criteria)
-      if criteria && !criteria.specific_occurrence.nil? && !sdc.nil? && 
-          sdc.specific_occurrence.nil? && !find(@source_data_criteria, :id, criteria.id).nil?
+      original_sdc = find(@source_data_criteria, :id, criteria.source_data_criteria)
+      updated_sdc = find(@source_data_criteria, :id, criteria.id)
+      if !updated_sdc.nil? && !criteria.specific_occurrence.nil? && 
+          (original_sdc.nil? || original_sdc.specific_occurrence.nil?)
         criteria.instance_variable_set(:@source_data_criteria, criteria.id)
       end
     end


### PR DESCRIPTION
Modified check for differences between source data criteria references (in specific occurrence data criteria) between parsed models, in order to align the parsed HQMF model to the parsed SimpleXML model.
