### PR TITLE
Fixed include_draft option in VSApiV2.

### DIFF
--- a/lib/health-data-standards/util/vs_api.rb
+++ b/lib/health-data-standards/util/vs_api.rb
@@ -66,12 +66,12 @@ module HealthDataStandards
       def get_valueset(oid, options = {}, &block)
         version = options.fetch(:version, nil)
         include_draft = options.fetch(:include_draft, false)
-        profile = options.fetch(:profile, nil)
+        profile = options.fetch(:profile, DEFAULT_PROFILE)
         effective_date = options.fetch(:effective_date, nil)
         params = { id: oid, ticket: get_ticket }
         params[:version] = version if version
         params[:includeDraft] = 'yes' if include_draft
-        params[:profile] = (if profile then profile else DEFAULT_PROFILE end) if include_draft
+        params[:profile] = profile if include_draft
         params[:effectiveDate] = effective_date if effective_date
         begin
           vs = RestClient.get(api_url, :params=>params)

--- a/lib/health-data-standards/util/vs_api.rb
+++ b/lib/health-data-standards/util/vs_api.rb
@@ -52,6 +52,13 @@ module HealthDataStandards
     end
 
     class VSApiV2 < VSApi
+      
+      # This default profile is used when the include_draft option is true without a profile specified.
+      # The VSAC V2 API needs a profile to be specified when using includeDraft. Future work on this 
+      # class could include a function to fetch the list of profiles from the https://vsac.nlm.nih.gov/vsac/profiles
+      # call.
+      DEFAULT_PROFILE = "Most Recent CS Versions"
+      
       def initialize(ticket_url, api_url, username, password, ticket_granting_ticket = nil)
         super(ticket_url, api_url, username, password, ticket_granting_ticket)
       end
@@ -59,10 +66,12 @@ module HealthDataStandards
       def get_valueset(oid, options = {}, &block)
         version = options.fetch(:version, nil)
         include_draft = options.fetch(:include_draft, false)
+        profile = options.fetch(:profile, nil)
         effective_date = options.fetch(:effective_date, nil)
         params = { id: oid, ticket: get_ticket }
         params[:version] = version if version
         params[:includeDraft] = 'yes' if include_draft
+        params[:profile] = (if profile then profile else DEFAULT_PROFILE end) if include_draft
         params[:effectiveDate] = effective_date if effective_date
         begin
           vs = RestClient.get(api_url, :params=>params)

--- a/test/unit/util/vs_api_test.rb
+++ b/test/unit/util/vs_api_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 require 'webmock'
-class EntryTest < Minitest::Test
+class VSApiTest < Minitest::Test
   include WebMock::API
 
   def initialize(name = nil)
@@ -54,6 +54,26 @@ class EntryTest < Minitest::Test
     stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket" ,:version => valueset_xml_version}).to_return(:body=>valueset_xml)
     api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
     api.get_valueset("oid", version: valueset_xml_version) do |oid,vs|
+      assert_equal "oid", oid
+      assert_equal valueset_xml, vs
+    end
+  end
+  
+  def test_api_v2_with_include_draft_default_profile
+    valueset_xml = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23" version="Draft"></ValueSet></RetrieveValueSetResponse>}
+    stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket", :includeDraft=>"yes", :profile=>"Most Recent CS Versions"}).to_return(:body=>valueset_xml)
+    api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
+    api.get_valueset("oid", include_draft: true) do |oid,vs|
+      assert_equal "oid", oid
+      assert_equal valueset_xml, vs
+    end
+  end
+  
+  def test_api_v2_with_include_draft_specified_profile
+    valueset_xml = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23" version="Draft"></ValueSet></RetrieveValueSetResponse>}
+    stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket", :includeDraft=>"yes", :profile=>"Test Profile"}).to_return(:body=>valueset_xml)
+    api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
+    api.get_valueset("oid", include_draft: true, profile: "Test Profile") do |oid,vs|
       assert_equal "oid", oid
       assert_equal valueset_xml, vs
     end


### PR DESCRIPTION
- Added a default profile parameter when using the include_draft option.
  - The profile parameter is needed by VSAC V2 when using includeDraft.
- Added an option to get_valuests so a profile can be explicity provided.
- Fixed the class name of the VSApi tests to not conflict with another class of tests.
- Added unit tests for the cases dealing with include_draft and profile.
