### PR TITLE
Remove stray "l" after closing observation tag

### DIFF
--- a/templates/ccda/_social_history.ccda.erb
+++ b/templates/ccda/_social_history.ccda.erb
@@ -15,7 +15,7 @@
         <%== code_display(entry, {:preferred_code_sets => ['SNOMED-CT']}) %>
         <statusCode code="completed"/>
         <effectiveTime <%= value_or_null_flavor(entry.as_point_in_time) %>/>
-      </observation>l
+      </observation>
     </entry>
     <% end -%>
   </section>


### PR DESCRIPTION
Porting some of the C32 / CCDA generation to Swift and while I was comparing results I saw this stray "l".
