### PR TITLE
Fix map reduce infinite loop error

### DIFF
--- a/lib/health-data-standards/models/record.rb
+++ b/lib/health-data-standards/models/record.rb
@@ -109,6 +109,11 @@ class Record
     end
     self.send("#{section}=", unique_entries)
   end
+
+  def dedupe_section_naively!(section)
+    self.send("#{section}=", self.send(section).uniq)
+  end
+
   def dedup_section_merging_codes_and_values!(section)
     unique_entries = {}
     self.send(section).each do |entry|
@@ -121,13 +126,19 @@ class Record
       else
         unique_entries[entry.identifier] = entry
       end
-      
+
     end
     self.send("#{section}=", unique_entries.values)
   end
 
   def dedup_section!(section)
-    [:encounters, :procedures, :results].include?(section) ? dedup_section_merging_codes_and_values!(section) : dedup_section_ignoring_content!(section)
+    if [:encounters, :procedures, :results].include?(section)
+      dedup_section_merging_codes_and_values!(section)
+    elsif [:medications].include?(section)
+      dedupe_section_naively!(section)
+    else
+      dedup_section_ignoring_content!(section)
+    end
   end
   def dedup_record!
     Record::Sections.each {|section| self.dedup_section!(section)}

--- a/lib/health-data-standards/models/record.rb
+++ b/lib/health-data-standards/models/record.rb
@@ -110,7 +110,7 @@ class Record
     self.send("#{section}=", unique_entries)
   end
 
-  def dedupe_section_naively!(section)
+  def dedup_section_naively!(section)
     self.send("#{section}=", self.send(section).uniq)
   end
 
@@ -126,7 +126,6 @@ class Record
       else
         unique_entries[entry.identifier] = entry
       end
-
     end
     self.send("#{section}=", unique_entries.values)
   end
@@ -135,11 +134,12 @@ class Record
     if [:encounters, :procedures, :results].include?(section)
       dedup_section_merging_codes_and_values!(section)
     elsif [:medications].include?(section)
-      dedupe_section_naively!(section)
+      dedup_section_naively!(section)
     else
       dedup_section_ignoring_content!(section)
     end
   end
+
   def dedup_record!
     Record::Sections.each {|section| self.dedup_section!(section)}
   end

--- a/test/fixtures/records/patient_with_duplicated_medications_section.json
+++ b/test/fixtures/records/patient_with_duplicated_medications_section.json
@@ -1,0 +1,2044 @@
+{
+  "_id": "56a010fa336da84c1e000000",
+  "addresses": [
+    {
+      "_id": "56a010fa336da84c1e000054",
+      "city": "Bedford",
+      "country": "US",
+      "state": "MA",
+      "street": [
+        "202 Burlington Rd."
+      ],
+      "use": "HP",
+      "zip": "01730"
+    }
+  ],
+  "birthdate": 1308405600,
+  "created_at": "2016-01-20T22:58:02.009Z",
+  "deathdate": null,
+  "effective_time": 1414178242,
+  "encounters": [
+    {
+      "_id": "56a010fa336da84c1e000001",
+      "admitTime": 1314882000,
+      "admitType": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000002",
+        "extension": "544a4359636f6e55ee320200",
+        "root": "1.3.6.1.4.1.115"
+      },
+      "codes": {
+        "CPT": [
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201"
+        ]
+      },
+      "description": "Encounter, Performed: Office Visit",
+      "diagnosis": null,
+      "dischargeDisposition": null,
+      "dischargeTime": 1314885600,
+      "end_time": 1314885600,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.79",
+      "performer_id": null,
+      "principalDiagnosis": null,
+      "reason": null,
+      "specifics": null,
+      "start_time": 1314882000,
+      "status_code": {
+        "HL7 ActStatus": [
+          "performed"
+        ]
+      },
+      "time": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000003",
+      "admitTime": 1330610400,
+      "admitType": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000004",
+        "extension": "544a4359636f6e55ee330200",
+        "root": "1.3.6.1.4.1.115"
+      },
+      "codes": {
+        "CPT": [
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201"
+        ]
+      },
+      "description": "Encounter, Performed: Office Visit",
+      "diagnosis": null,
+      "dischargeDisposition": null,
+      "dischargeTime": 1330614000,
+      "end_time": 1330614000,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.79",
+      "performer_id": null,
+      "principalDiagnosis": null,
+      "reason": null,
+      "specifics": null,
+      "start_time": 1330610400,
+      "status_code": {
+        "HL7 ActStatus": [
+          "performed"
+        ]
+      },
+      "time": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000005",
+      "admitTime": 1354370400,
+      "admitType": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000006",
+        "extension": "544a4359636f6e55ee340200",
+        "root": "1.3.6.1.4.1.115"
+      },
+      "codes": {
+        "CPT": [
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201"
+        ]
+      },
+      "description": "Encounter, Performed: Office Visit",
+      "diagnosis": null,
+      "dischargeDisposition": null,
+      "dischargeTime": 1354374000,
+      "end_time": 1354374000,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.79",
+      "performer_id": null,
+      "principalDiagnosis": null,
+      "reason": null,
+      "specifics": null,
+      "start_time": 1354370400,
+      "status_code": {
+        "HL7 ActStatus": [
+          "performed"
+        ]
+      },
+      "time": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000007",
+      "admitTime": 1364821200,
+      "admitType": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000008",
+        "extension": "544a4359636f6e55ee350200",
+        "root": "1.3.6.1.4.1.115"
+      },
+      "codes": {
+        "CPT": [
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201",
+          "99201"
+        ]
+      },
+      "description": "Encounter, Performed: Office Visit",
+      "diagnosis": null,
+      "dischargeDisposition": null,
+      "dischargeTime": 1364824800,
+      "end_time": 1364824800,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.79",
+      "performer_id": null,
+      "principalDiagnosis": null,
+      "reason": null,
+      "specifics": null,
+      "start_time": 1364821200,
+      "status_code": {
+        "HL7 ActStatus": [
+          "performed"
+        ]
+      },
+      "time": null
+    }
+  ],
+  "ethnicity": {
+    "code": "2186-5",
+    "code_set": "CDC-RE"
+  },
+  "expired": null,
+  "first": "GP_Peds",
+  "gender": "M",
+  "insurance_providers": [
+    {
+      "_id": "56a010fa336da84c1e000053",
+      "codes": {
+        "SOP": [
+          "349"
+        ]
+      },
+      "description": null,
+      "end_time": null,
+      "financial_responsibility_type": null,
+      "member_id": null,
+      "mood_code": "EVN",
+      "name": null,
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.405",
+      "reason": null,
+      "relationship": null,
+      "specifics": null,
+      "start_time": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          null
+        ]
+      },
+      "time": null,
+      "type": null
+    }
+  ],
+  "languages": [
+    "eng"
+  ],
+  "last": "E",
+  "marital_status": null,
+  "medical_record_assigner": null,
+  "medical_record_number": "12345",
+  "medications": [
+    {
+      "_id": "56a010fa336da84c1e000009",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00000a",
+        "extension": null,
+        "root": "4e261390-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "120"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Hemophilus Influenze B (HiB) Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1314885600,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1314885600,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00000b",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00000c",
+        "extension": null,
+        "root": "4e265fc0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "106"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: DTaP Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1314885600,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1314885600,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00000d",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00000e",
+        "extension": null,
+        "root": "4e26a460-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "120"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Hemophilus Influenze B (HiB) Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1330614000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1330614000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00000f",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000010",
+        "extension": null,
+        "root": "4e26fb70-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "106"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: DTaP Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1330614000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1330614000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000011",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000012",
+        "extension": null,
+        "root": "4e2749e0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "106"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: DTaP Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1354374000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1354374000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000013",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000014",
+        "extension": null,
+        "root": "4e278820-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "120"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Hemophilus Influenze B (HiB) Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1354374000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1354374000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000015",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000016",
+        "extension": null,
+        "root": "4e27c9b0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "120"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Hemophilus Influenze B (HiB) Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1364824800,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1364824800,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000017",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000018",
+        "extension": null,
+        "root": "4e2808c0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "106"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: DTaP Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1364824800,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1364824800,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000019",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00001a",
+        "extension": null,
+        "root": "4e288220-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "120"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Hemophilus Influenze B (HiB) Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1314885600,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1314885600,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00001b",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00001c",
+        "extension": null,
+        "root": "4e28c570-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "120"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Hemophilus Influenze B (HiB) Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1330614000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1330614000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00001d",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00001e",
+        "extension": null,
+        "root": "4e290780-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "120"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Hemophilus Influenze B (HiB) Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1354374000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1354374000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00001f",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000020",
+        "extension": null,
+        "root": "4e294eb0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "120"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Hemophilus Influenze B (HiB) Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1364824800,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1364824800,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000021",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000022",
+        "extension": null,
+        "root": "4e29b600-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "08"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Hepatitis B Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1314885600,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1314885600,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000023",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000024",
+        "extension": null,
+        "root": "4e29fdc0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "08"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Hepatitis B Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1330614000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1330614000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000025",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000026",
+        "extension": null,
+        "root": "4e2a4260-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "08"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Hepatitis B Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1354374000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1354374000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000027",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000028",
+        "extension": null,
+        "root": "4e2a83b0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "08"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Hepatitis B Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1364824800,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1364824800,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000029",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00002a",
+        "extension": null,
+        "root": "4e2ac620-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "104"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Hepatitis A Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1364824800,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1364824800,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00002b",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00002c",
+        "extension": null,
+        "root": "4e2b4590-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "10"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Inactivated Polio Vaccine (IPV)",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1314885600,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1314885600,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00002d",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00002e",
+        "extension": null,
+        "root": "4e2b8700-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "10"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Inactivated Polio Vaccine (IPV)",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1330614000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1330614000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00002f",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000030",
+        "extension": null,
+        "root": "4e2bce30-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "10"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Inactivated Polio Vaccine (IPV)",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1354374000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1354374000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000031",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000032",
+        "extension": null,
+        "root": "4e2c0d90-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "10"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Inactivated Polio Vaccine (IPV)",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1362150000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1362150000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000033",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000034",
+        "extension": null,
+        "root": "4e2c7130-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "140"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Influenza Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1330614000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1330614000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000035",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000036",
+        "extension": null,
+        "root": "4e2caec0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "140"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Influenza Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1354374000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1354374000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000037",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000038",
+        "extension": null,
+        "root": "4e2cea40-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "140"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Influenza Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1364824800,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1364824800,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000039",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00003a",
+        "extension": null,
+        "root": "4e2d4fb0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "100"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Pneumococcal Conjugate Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1314885600,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1314885600,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00003b",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00003c",
+        "extension": null,
+        "root": "4e2d8c90-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "100"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Pneumococcal Conjugate Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1330614000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1330614000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00003d",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00003e",
+        "extension": null,
+        "root": "4e2dc970-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "100"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Pneumococcal Conjugate Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1354374000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1354374000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00003f",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000040",
+        "extension": null,
+        "root": "4e2e07e0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "100"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Pneumococcal Conjugate Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1364824800,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1364824800,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000041",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000042",
+        "extension": null,
+        "root": "4e2e8c30-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "116"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Rotavirus Vaccine (3 dose schedule)",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1330614000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1330614000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000043",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000044",
+        "extension": null,
+        "root": "4e2ed4f0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "116"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Rotavirus Vaccine (3 dose schedule)",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1354374000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1354374000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000045",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000046",
+        "extension": null,
+        "root": "4e2f3500-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "116"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Rotavirus Vaccine (3 dose schedule)",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1364824800,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1364824800,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000047",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000048",
+        "extension": null,
+        "root": "4e2fb710-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "104"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Hepatitis A Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1364824800,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1364824800,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000049",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00004a",
+        "extension": null,
+        "root": "4e312e20-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "03"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Measles, Mumps and Rubella (MMR) Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1364824800,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1364824800,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00004b",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00004c",
+        "extension": null,
+        "root": "4e31b5b0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "21"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Varicella Zoster Vaccine (VZV)",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1364824800,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1364824800,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00004d",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e00004e",
+        "extension": null,
+        "root": "4e38a2c0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "140"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Influenza Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1330614000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1330614000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e00004f",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000050",
+        "extension": null,
+        "root": "4e38e7e0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "140"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Influenza Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1354374000,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1354374000,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    },
+    {
+      "_id": "56a010fa336da84c1e000051",
+      "active_datetime": null,
+      "administrationTiming": null,
+      "anatomical_approach": null,
+      "cda_identifier": {
+        "_id": "56a010fa336da84c1e000052",
+        "extension": null,
+        "root": "4e3931e0-3de0-0132-47ea-0050560104e4"
+      },
+      "codes": {
+        "CVX": [
+          "140"
+        ]
+      },
+      "cumulativeMedicationDuration": null,
+      "deliveryMethod": null,
+      "description": "Medication, Administered: Influenza Vaccine",
+      "dose": null,
+      "doseIndicator": null,
+      "doseRestriction": null,
+      "end_time": 1364824800,
+      "freeTextSig": null,
+      "fulfillmentInstructions": null,
+      "indication": null,
+      "method": null,
+      "mood_code": "EVN",
+      "negationInd": null,
+      "negationReason": null,
+      "oid": "2.16.840.1.113883.3.560.1.14",
+      "patientInstructions": null,
+      "productForm": null,
+      "reaction": null,
+      "reason": null,
+      "route": null,
+      "signed_datetime": null,
+      "specifics": null,
+      "start_time": 1364824800,
+      "statusOfMedication": null,
+      "status_code": {
+        "HL7 ActStatus": [
+          "administered"
+        ]
+      },
+      "time": null,
+      "typeOfMedication": null,
+      "vehicle": null
+    }
+  ],
+  "race": {
+    "code": "2028-9",
+    "code_set": "CDC-RE"
+  },
+  "religious_affiliation": null,
+  "telecoms": [
+    {
+      "_id": "56a010fa336da84c1e000055",
+      "preferred": null,
+      "use": "WP",
+      "value": "tel:+1-781-271-3000"
+    }
+  ],
+  "test_id": null,
+  "title": null,
+  "updated_at": "2016-01-20T22:58:02.009Z"
+}

--- a/test/unit/models/record_test.rb
+++ b/test/unit/models/record_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class RecordTest < Minitest::Test
+  def setup
+    collection_fixtures('records')
+  end
 
   def test_entries_for_oid
     record = FactoryGirl.create(:bigger_record)
@@ -96,7 +99,7 @@ class RecordTest < Minitest::Test
 
   def test_dedup_section_naively
     # fixture: patient_with_duplicated_medications_section.json
-    record = Record.where(first: "GP_Peds").first
+    record = Record.where(first: 'GP_Peds').first
 
     assert_equal 37, record.medications.size
 

--- a/test/unit/models/record_test.rb
+++ b/test/unit/models/record_test.rb
@@ -93,4 +93,15 @@ class RecordTest < Minitest::Test
 
     assert_equal 3, record.encounters.size
   end
+
+  def test_dedup_section_naively
+    # fixture: patient_with_duplicated_medications_section.json
+    record = Record.where(first: "GP_Peds").first
+
+    assert_equal 37, record.medications.size
+
+    record.dedup_record!
+
+    assert_equal 29, record.medications.size
+  end
 end


### PR DESCRIPTION
Quoting from https://github.com/q-centrix/health-data-standards/pull/6:

> Duplicate :medications information was causing the map_fn for Child Immunization Status (40280381-4555-E1C1-0145-D7C003364261) to go into an infinite loop during mongo's mapreduce, eating up 100% CPU, and eventually causing a memory leak. Although the BulkRecordImporter calls PatientImporter which calls Record's dedup_record! method, the :medications sections still were not being deduped. This fix uses ruby's uniq method to dedupe :medications rather than using more domain-specific approaches. This fixes the infinite loop error, and turns the corresponding Cypress tests green.

It looks like this measure was skipped in Cypress for a while: https://github.com/projectcypress/cypress/commit/450178b5e1faeb04550051faa56eafbcc1f0c78b

Someone else commenting with the same issue: https://github.com/OSEHRA/popHealth/issues/1#issuecomment-136735186

Identified as an issue by the pophealth team: http://issues.osehra.org/browse/POP-270

Please let me know if this is not the correct approach! I am using these commits in a fork currently and would like to update if there's a better solution.
