### PR TITLE
Added code to export/import laterality info 

### DIFF
--- a/lib/health-data-standards/export/view_helper.rb
+++ b/lib/health-data-standards/export/view_helper.rb
@@ -33,6 +33,11 @@ module HealthDataStandards
             code_string += "<translation code=\"#{translation['code']}\" codeSystem=\"#{HealthDataStandards::Util::CodeSystemHelper.oid_for_code_system(translation['code_set'])}\"/>\n"
           end
         end
+
+        if options["laterality"]
+          code_string += "\n<!-- QDM Attribute: Laterality -->\n<qualifier>\n<name code='182353008' codeSystem='2.16.840.1.113883.6.96' displayName='Side' />\n"
+          code_string += "<value xsi:type='CD' code='#{options['laterality']['code']}' displayName='#{options['laterality']['title']}' codeSystem='#{HealthDataStandards::Util::CodeSystemHelper.oid_for_code_system(options['laterality']['code_system'])}'/>\n</qualifier>\n"
+        end
         
         code_string += "</#{options['tag_name']}>"
 

--- a/lib/health-data-standards/import/cat1/diagnosis_active_importer.rb
+++ b/lib/health-data-standards/import/cat1/diagnosis_active_importer.rb
@@ -8,11 +8,13 @@ module HealthDataStandards
           @status_xpath = nil # We'll hardcode this to active in create entry because this is from the 
                               # diagnosis active template
           @severity_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.22.4.8']/cda:value"                    
+          @laterality_xpath = "./cda:value/cda:qualifier[cda:name/@code='182353008']/cda:value"
         end
 
         def create_entry(entry_element, nrh = NarrativeReferenceHandler.new)
           condition = super(entry_element,nrh)
           extract_severity(entry_element,condition)
+          extract_laterality(entry_element,condition)
           condition
         end
 
@@ -22,6 +24,14 @@ module HealthDataStandards
             condition.severity = {CodeSystemHelper.code_system_for(severity['codeSystem']) => [severity['code']]}
           end
         end
+
+        def extract_laterality(entry_element,condition)
+          laterality = entry_element.at_xpath(@laterality_xpath)
+          if laterality
+            condition.laterality = { 'code_system' => CodeSystemHelper.code_system_for(laterality['codeSystem']), 'code' => laterality['code'] }
+          end
+        end
+
       end
     end
   end

--- a/lib/health-data-standards/models/condition.rb
+++ b/lib/health-data-standards/models/condition.rb
@@ -5,7 +5,7 @@ class Condition < Entry
   field :priority,          type: Integer
   field :name,              type: String
   field :ordinality,        type: Hash
-  field :severity,          type: Hash # Currently unsupported by any importers
+  field :severity,          type: Hash
   field :laterality,        type: Hash
   field :anatomical_target, type: Hash
   field :anatomical_location, type: Hash

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.11.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.11.cat1.erb
@@ -41,7 +41,7 @@
     <%== render(:partial => 'ordinality', :locals => {:entry => entry, :ordinality_oids=>field_oids["ORDINAL"]}) %>
     
     <%== code_display(entry, {'tag_name' => 'value', 'value_set_map' => value_set_map,'preferred_code_sets' => ['LOINC', 'SNOMED-CT', 'ICD-9-CM', 'ICD-10-CM'],
-                                                    'extra_content' => "xsi:type=\"CD\" sdtc:valueSet=\"#{value_set_oid}\""}) %>
+                                                    'extra_content' => "xsi:type=\"CD\" sdtc:valueSet=\"#{value_set_oid}\"", 'laterality' => entry.laterality}) %>
 
     <entryRelationship typeCode="REFR">
       <observation classCode="OBS" moodCode="EVN">


### PR DESCRIPTION
If present, export laterality (side of body) info from Diagnosis, Active, and code to import it in the Diagnosis, Active importer. Needed for unilateral (one-sided) amputation Diagnoses, so you can indicate which limb was amputated.
