### PR TITLE
Added a .gitattributes file to set resources/schema and resources/schematron as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+resources/schema/* linguist-vendored
+resource/schematron/* linguist-vendored


### PR DESCRIPTION
(this excludes it from language statistics, and diffs on github.com). This is useful because the schematrons in resources/schematron are ~50% of HDS's current codebase, so we're getting marked as a KiCad project rather than a Ruby one.
