### PR TITLE
Bumped nokogiri for bundle-audit compliance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ PATH
       memoist (~> 0.9.1)
       mongoid (~> 4.0.0)
       mongoid-tree (~> 1.0.4)
-      nokogiri (~> 1.6.7.1)
+      nokogiri (~> 1.6.8)
       protected_attributes (~> 1.0.5)
       rest-client (~> 1.8.0)
       rubyzip (= 0.9.9)
@@ -47,7 +47,7 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     docile (1.1.5)
-    domain_name (0.5.25)
+    domain_name (0.5.20160310)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     factory_girl (4.1.0)
@@ -63,8 +63,8 @@ GEM
     macaddr (1.7.1)
       systemu (~> 2.6.2)
     memoist (0.9.3)
-    mime-types (2.99)
-    mini_portile2 (2.0.0)
+    mime-types (2.99.2)
+    mini_portile2 (2.1.0)
     minitest (5.8.4)
     minitest-reporters (1.0.17)
       ansi
@@ -83,11 +83,13 @@ GEM
       connection_pool (~> 2.0)
       optionable (~> 0.2.0)
     netrc (0.11.0)
-    nokogiri (1.6.7.1)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     optionable (0.2.0)
-    origin (2.1.1)
+    origin (2.2.0)
     parallel (1.6.0)
+    pkg-config (1.1.7)
     protected_attributes (1.0.9)
       activemodel (>= 4.0.1, < 5.0)
     rake (10.4.2)
@@ -118,7 +120,7 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     uuid (2.3.8)
       macaddr (~> 1.0)
     webmock (1.21.0)
@@ -144,4 +146,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.12.1
+   1.12.5

--- a/health-data-standards.gemspec
+++ b/health-data-standards.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'protected_attributes', '~> 1.0.5'
   s.add_dependency 'uuid', '~> 2.3.7'
   s.add_dependency 'builder', '~> 3.1'
-  s.add_dependency 'nokogiri', '~> 1.6.7.1'
+  s.add_dependency 'nokogiri', '~> 1.6.8'
   s.add_dependency 'highline', "~> 1.7.0"
 
   s.add_dependency 'rubyzip', '0.9.9'


### PR DESCRIPTION
Note: only Nokogiri was updated in this pull request; not ActiveModel.
