### PR TITLE
Cat1R3 export fixes

### DIFF
--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.11.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.11.cat1.erb
@@ -51,10 +51,11 @@
                 sdtc:valueSet="<%= oid_for_code(entry.laterality,field_oids["LATERALITY"] || [], entry.record["bundle_id"]) %>"
             />
     <% end %>
+    <% if r2_compatibility %>
     <entryRelationship typeCode="REFR">
       <observation classCode="OBS" moodCode="EVN">
         <!-- Problem Status (consolidation) template -->
-        <templateId root="2.16.840.1.113883.10.20.22.4.6" <% if !r2_compatibility %>extension="2014-06-09"<%end%>/>
+        <templateId root="2.16.840.1.113883.10.20.22.4.6" extension="2014-06-09"/>
         <!-- Problem Status, Active template -->
         <templateId root="2.16.840.1.113883.10.20.24.3.94" extension="2015-04-06"/>
         <id root="<%= UUID.generate %>"/>  
@@ -69,6 +70,7 @@
            codeSystemName="SNOMED CT"/>
       </observation>
     </entryRelationship>
+    <% end %>
     <% if entry.severity %>
     <entryRelationship typeCode="REFR">
        <observation classCode="OBS" moodCode="EVN">

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.13.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.13.cat1.erb
@@ -33,21 +33,21 @@
   <%== render(:partial => 'ordinality', :locals => {:entry => entry, :ordinality_oids=>field_oids["ORDINAL"]}) %>
 
   <%== code_display(entry, 'value_set_map' => filtered_vs_map,'tag_name' => 'value', 'preferred_code_sets' => ['SNOMED-CT', 'ICD-9-CM', 'ICD-10-CM', 'LOINC'], 'extra_content' => "xsi:type=\"CD\" sdtc:valueSet=\"#{value_set_oid}\"") %>
+  <% if r2_compatibility %>
   <!-- Status -->
   <entryRelationship typeCode="REFR">
     <observation classCode="OBS" moodCode="EVN">
       <!-- Problem Status (consolidation) template -->
-      <templateId root="2.16.840.1.113883.10.20.22.4.6" <% if !r2_compatibility %>extension="2014-06-09"<%end%>/>
+      <templateId root="2.16.840.1.113883.10.20.22.4.6"/>
       <!-- Problem Status, Inactive template -->
-      <templateId root="2.16.840.1.113883.10.20.24.3.95" <% if !r2_compatibility %>extension="2014-12-01"<%end%>/>
+      <templateId root="2.16.840.1.113883.10.20.24.3.95"/>
       <id root="<%= UUID.generate %>"/>
       <code code="33999-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="status"/>  
       <statusCode code="completed"/>  
       <value code="73425007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="inactive" xsi:type="CD"/>
     </observation>
-
   </entryRelationship>
-  
+  <% end %>
   </observation>
   </entryRelationship>
   </act>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.14.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.14.cat1.erb
@@ -33,19 +33,21 @@
 
     <%== code_display(entry, 'value_set_map' => filtered_vs_map,'tag_name' => 'value', 'preferred_code_sets' => ['SNOMED-CT', 'ICD-9-CM', 'ICD-10-CM', 'CPT'],
                              'extra_content' => "xsi:type=\"CD\" sdtc:valueSet=\"#{value_set_oid}\"") %>
+    <% if r2_compatibility %>
     <!-- Status -->
     <entryRelationship typeCode="REFR">
       <observation classCode="OBS" moodCode="EVN">
         <!-- Problem Status (consolidation) template -->
-        <templateId root="2.16.840.1.113883.10.20.22.4.6" <% if !r2_compatibility %>extension="2014-06-09"<%end%>/>
+        <templateId root="2.16.840.1.113883.10.20.22.4.6"/>
         <!-- Problem Status, Resolved template -->
-        <templateId root="2.16.840.1.113883.10.20.24.3.96" <% if !r2_compatibility %>extension="2014-12-01"<%end%>/>
+        <templateId root="2.16.840.1.113883.10.20.24.3.96"/>
         <id root="<%= UUID.generate %>"/>
         <code code="33999-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="status"/>
         <statusCode code="completed"/>
         <value code="413322009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="resolved" xsi:type="CD"/>
       </observation>
     </entryRelationship>
+    <% end %>
   </observation>
   </entryRelationship>
   </act>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.22.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.22.cat1.erb
@@ -7,7 +7,7 @@
     <id root="1.3.6.1.4.1.115" extension="<%= entry.id %>"/>
     <%== code_display(entry, 'preferred_code_sets' => ['SNOMED-CT', 'ICD-9-CM', 'ICD-10-CM', 'CPT'], 'value_set_map' => filtered_vs_map, 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
     <text><%= entry.description %></text>
-    <statusCode code="<%= r2_comptibility ? 'new' : 'active' %>"/>
+    <statusCode code="<%= r2_compatibility ? 'new' : 'active' %>"/>
   
     <!-- Attribute: datetime -->
     <author>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.22.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.22.cat1.erb
@@ -7,7 +7,7 @@
     <id root="1.3.6.1.4.1.115" extension="<%= entry.id %>"/>
     <%== code_display(entry, 'preferred_code_sets' => ['SNOMED-CT', 'ICD-9-CM', 'ICD-10-CM', 'CPT'], 'value_set_map' => filtered_vs_map, 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
     <text><%= entry.description %></text>
-    <statusCode code="new"/>
+    <statusCode code="<%= r2_comptibility ? 'new' : 'active' %>"/>
   
     <!-- Attribute: datetime -->
     <author>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.22_2016_02_01.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.22_2016_02_01.cat1.erb
@@ -7,7 +7,7 @@
     <id root="1.3.6.1.4.1.115" extension="<%= entry.id %>"/>
     <%== code_display(entry, 'preferred_code_sets' => ['SNOMED-CT', 'ICD-9-CM', 'ICD-10-CM', 'CPT'], 'value_set_map' => filtered_vs_map, 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
     <text><%= entry.description %></text>
-    <statusCode code="new"/>
+    <statusCode code="active"/>
   
     <!-- Attribute: datetime -->
     <author>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.63.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.63.cat1.erb
@@ -7,7 +7,7 @@
     <id root="1.3.6.1.4.1.115" extension="<%= entry.id %>"/>
     <%== code_display(entry, 'value_set_map' => filtered_vs_map, 'preferred_code_sets' => ['LOINC', 'SNOMED-CT', 'ICD-9-PCS', 'ICD-10-PCS'], 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
     <text><%= entry.description %></text>
-    <statusCode code="new"/>
+    <statusCode code="<%= r2_comptibility ? 'new' : 'active' %>"/>
     <!-- Attribute: datetime --> 
     <author>
       <templateId root="2.16.840.1.113883.10.20.22.4.119"/>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.63.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.63.cat1.erb
@@ -7,7 +7,7 @@
     <id root="1.3.6.1.4.1.115" extension="<%= entry.id %>"/>
     <%== code_display(entry, 'value_set_map' => filtered_vs_map, 'preferred_code_sets' => ['LOINC', 'SNOMED-CT', 'ICD-9-PCS', 'ICD-10-PCS'], 'extra_content' => "sdtc:valueSet=\"#{value_set_oid}\"") %>
     <text><%= entry.description %></text>
-    <statusCode code="<%= r2_comptibility ? 'new' : 'active' %>"/>
+    <statusCode code="<%= r2_compatibility ? 'new' : 'active' %>"/>
     <!-- Attribute: datetime --> 
     <author>
       <templateId root="2.16.840.1.113883.10.20.22.4.119"/>

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.76.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.76.cat1.erb
@@ -16,11 +16,12 @@
     </effectiveTime>
     
      <%== code_display(entry, 'value_set_map' => filtered_vs_map,'preferred_code_sets' => ['SNOMED-CT'], 'tag_name' => 'value', 'extra_content' => "xsi:type=\"CD\" sdtc:valueSet=\"#{value_set_oid}\"") %>
+     <% if r2_compatibility %>
     <!-- Status -->
     <entryRelationship typeCode="REFR">
       <observation classCode="OBS" moodCode="EVN">
         <!-- Problem Status (consolidation) template -->
-        <templateId root="2.16.840.1.113883.10.20.22.4.6" <% if !r2_compatibility %>extension="2014-06-09"<%end%>/>
+        <templateId root="2.16.840.1.113883.10.20.22.4.6"/>
         <!-- Problem Status, Active template -->
         <templateId root="2.16.840.1.113883.10.20.24.3.94"/>
         <id root="<%= UUID.generate %>"/>  
@@ -29,5 +30,6 @@
         <value code="55561003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="active" xsi:type="CD"/>
       </observation>
     </entryRelationship>
+    <% end %>
   </observation>
 </entry>


### PR DESCRIPTION
Fixes 2 issues with Cat I R3 export:

**1. Replaced instances of statusCode="new" with statusCode="active" for R3.**

Ref:
https://jira.oncprojectracking.org/secure/attachment/19047/QRDA_CAT_I_R2_to_R3.pdf , p23
CDAR2_QRDA_I_R1_D3_2015JUN_Vol1_Introductory_Material.pdf, Table 7: High-Level Change Log ~p66,67

**2. Removed Problem Status templates in R3**
Problem Status has been deprecated in R3 and the child templates (Problem Status, Active; Problem Status, Inactive; Problem Status, Resolved) have been retired

Ref:
CDAR2_QRDA_I_R1_D3_2015JUN_Vol2_Templates_and_Supporting.pdf
"4.47 Problem Status (DEPRECATED) - Deprecated",  p526
"Table 362: Retired Templates", p743
