### PR TITLE
Changed bundle download location

### DIFF
--- a/lib/health-data-standards/tasks/bundle.rake
+++ b/lib/health-data-standards/tasks/bundle.rake
@@ -50,7 +50,7 @@ namespace :bundle do
 
     puts "Downloading and saving #{@bundle_name} to #{measures_dir}"
     # Pull down the list of bundles and download the version we're looking for
-    bundle_uri = "https://demo.projectcypress.org/bundles/#{@bundle_name}"
+    bundle_uri = "https://cypressdemo.healthit.gov/measure_bundles/#{@bundle_name}"
     bundle = nil
 
     tries = 0


### PR DESCRIPTION
Changed bundle download location to correspond with the new Cypress demo server URL

OLD: https://demo.projectcypress.org/bundles

NEW: https://cypressdemo.healthit.gov/measure_bundles
