### PR TITLE
Made "Medication, Order" cumulative medication duration calculate correctly. 

### DIFF
--- a/lib/health-data-standards/import/cda/medication_importer.rb
+++ b/lib/health-data-standards/import/cda/medication_importer.rb
@@ -39,6 +39,8 @@ module HealthDataStandards
           medication.indication = extract_code(entry_element, @indication_xpath, 'SNOMED-CT')
           medication.vehicle = extract_code(entry_element, @vehicle_xpath, 'SNOMED-CT')
 
+          medication.allowed_administrations = extract_scalar(entry_element, "./cda:repeatNumber")
+
           extract_order_information(entry_element, medication)
 
           extract_fulfillment_history(entry_element, medication)

--- a/lib/health-data-standards/models/medication.rb
+++ b/lib/health-data-standards/models/medication.rb
@@ -22,6 +22,19 @@ class Medication < Entry
   field :method ,   type: Hash 
   field :active_datetime ,  type: Integer
   field :signed_datetime ,  type: Integer
+  
+  # This is used for Medicaton, Order. It is the total number of times a dose of a particular
+  # medication can be administered. This, coupled with the administrationTiming will
+  # give the cumulative medication duration.
+  # E.g.
+  #  allowedAdministrations = 90 doses
+  #  administrationTiming = 1 dose / 12 hours
+  #  cumulativeMedicationDuration = allowedAdministrations / administrationTiming * (time conversion)
+  #  cumulativeMedicationDuration = (90 doses) * (12 hours)/(1 dose) * (1 day)/(24 hours) = 45 days
+  # Medication, Order can't use fulfillmentHistory because the fulfillment of the 
+  # medication has not yet happened.
+  # This corresponds to 'repeatNumber' in the QRDA representation
+  field :allowedAdministrations, as: :allowed_administrations, type: Integer
 
   # There are currently no importers that support this field
   # It is expected to be a scalar and value, such as 7 days

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.47.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.47.cat1.erb
@@ -21,6 +21,9 @@
         <period value="<%= period['value']%>" unit="<%= period['unit']%>"/>
       </effectiveTime>
     <% end %>
+    <% if entry.allowedAdministrations.present? %>
+      <repeatNumber value="<%== entry.allowedAdministrations %>" />
+    <% end %>
      <%== render(:partial => 'medication_details', :locals => {:entry => entry, :route_oids=>field_oids["ROUTE"]}) %>
     <consumable>
       <manufacturedProduct classCode="MANU">

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.47_2016_02_01.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.47_2016_02_01.cat1.erb
@@ -21,6 +21,9 @@
         <period value="<%= period['value']%>" unit="<%= period['unit']%>"/>
       </effectiveTime>
     <% end %>
+    <% if entry.allowedAdministrations.present? %>
+      <repeatNumber value="<%== entry.allowedAdministrations %>" />
+    <% end %>
      <%== render(:partial => 'medication_details', :locals => {:entry => entry, :route_oids=>field_oids["ROUTE"]}) %>
     <consumable>
       <manufacturedProduct classCode="MANU">


### PR DESCRIPTION
This addresses https://oncprojectracking.healthit.gov/support/browse/BONNIE-172.

Usually, cumulative medication duration is calculated based off of the fulfillment history, dose, and regimen. However, for "Medication, Order", the medication has not yet been filled, so fulfillment history and dose don't make sense. Maybe more importantly, these fields are not available in the QRDA for the "Medication, Order" template.

Instead, cumulative medication duration should be calculated based on the maximum allowed administrations (`repeatNumber` in the QRDA) and the regimen (`effectiveTime` with `period` subelement in the QRDA).

Additionally, fulfillment information should not be allowed to be entered for "Medication, Order".

Specific changes for this repository include adding `allowedAdministrations` to the medication model and including `repeateNumber` in the "Medication, Ordered" QRDA templates.

This pull request depends on the `medication_order_cmd` branches in **bonnie, hqmf2js, and patient-api.**
