### PR TITLE
Display name was incorrect for 2.16.840.1.113883.10.20.24.3.82

### DIFF
--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.81.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.81.cat1.erb
@@ -1,7 +1,7 @@
 <entry>
 	<encounter classCode="ENC" moodCode="EVN">
 		<templateId root="2.16.840.1.113883.10.20.24.3.81" <% if !r2_compatibility %>extension="2014-12-01"<%end%>/>
-		<id root="1.3.6.1.4.1.115" extension="<%= entry.transferFrom.id %>"/>
+    	<id root="1.3.6.1.4.1.115" extension="<%= "#{entry.transferFrom.id}#{entry.id}".hash.abs.to_s(16) %>"/>
 		<code code="77305-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="transferred from"/>
 		<statusCode code="completed"/>
 		<participant typeCode="ORG">

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.81.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.81.cat1.erb
@@ -1,7 +1,7 @@
 <entry>
 	<encounter classCode="ENC" moodCode="EVN">
 		<templateId root="2.16.840.1.113883.10.20.24.3.81" <% if !r2_compatibility %>extension="2014-12-01"<%end%>/>
-    	<id root="1.3.6.1.4.1.115" extension="<%= "#{entry.transferFrom.id}#{entry.id}".hash.abs.to_s(16) %>"/>
+		<id root="1.3.6.1.4.1.115" extension="<%= "#{entry.transferFrom.id}#{entry.id}".hash.abs.to_s(16) %>"/>
 		<code code="77305-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="transferred from"/>
 		<statusCode code="completed"/>
 		<participant typeCode="ORG">

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.81_2016_02_01.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.81_2016_02_01.cat1.erb
@@ -1,7 +1,7 @@
 <entry>
 	<encounter classCode="ENC" moodCode="EVN">
 		<templateId root="2.16.840.1.113883.10.20.24.3.81" extension="2016-02-01"/>
-		<id root="1.3.6.1.4.1.115" extension="<%= entry.transferFrom.id %>"/>
+    	<id root="1.3.6.1.4.1.115" extension="<%= "#{entry.transferFrom.id}#{entry.id}".hash.abs.to_s(16) %>"/>
 		<code code="77305-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="transferred from"/>
 		<statusCode code="completed"/>
 		<participant typeCode="ORG">

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.81_2016_02_01.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.81_2016_02_01.cat1.erb
@@ -1,7 +1,7 @@
 <entry>
 	<encounter classCode="ENC" moodCode="EVN">
 		<templateId root="2.16.840.1.113883.10.20.24.3.81" extension="2016-02-01"/>
-    	<id root="1.3.6.1.4.1.115" extension="<%= "#{entry.transferFrom.id}#{entry.id}".hash.abs.to_s(16) %>"/>
+		<id root="1.3.6.1.4.1.115" extension="<%= "#{entry.transferFrom.id}#{entry.id}".hash.abs.to_s(16) %>"/>
 		<code code="77305-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="transferred from"/>
 		<statusCode code="completed"/>
 		<participant typeCode="ORG">

--- a/templates/cat1/_2.16.840.1.113883.10.20.24.3.82_2016_02_01.cat1.erb
+++ b/templates/cat1/_2.16.840.1.113883.10.20.24.3.82_2016_02_01.cat1.erb
@@ -1,6 +1,6 @@
 <entry>
   <encounter classCode="ENC" moodCode="EVN">
-  	<templateId root="2.16.840.1.113883.10.20.24.3.82" <% if !r2_compatibility %>extension="2014-12-01"<%end%>/>
+  	<templateId root="2.16.840.1.113883.10.20.24.3.82" extension="2016-02-01"/>
     <id root="1.3.6.1.4.1.115" extension="<%= "#{entry.transferTo.id}#{entry.id}".hash.abs.to_s(16) %>"/>
   	<code code="77306-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Discharge disposition"/>
   	<statusCode code="completed"/>


### PR DESCRIPTION
TransferFrom and TransferTo ids are not randomized when patients are cloned, when the id is exported, use the hash of the transfer and encounter id
