### PR TITLE
Makes version required for bundle download task

### DIFF
--- a/lib/health-data-standards/tasks/bundle.rake
+++ b/lib/health-data-standards/tasks/bundle.rake
@@ -26,12 +26,15 @@ namespace :bundle do
     options
     nlm_user    - the nlm username to authenticate to the server - will prompt is not supplied
     nlm_passwd  - the nlm password for authenticating to the server - will prompt if not supplied
-    version     - the version of the bundle to download. This will default to the version
+    version     - the version of the bundle to download - this must be supplied
 
    example usage:
     rake bundle:download nlm_name=username nlm_passwd=password version=2.1.0-latest
   }
   task :download => :environment do
+    bundle_version = ENV.fetch("version") do
+      raise ArgumentError.new("Required argument 'version' was not supplied")
+    end
     nlm_user = ENV["nlm_user"]
     nlm_passwd = ENV["nlm_pass"]
     measures_dir = File.join(Dir.pwd, "bundles")
@@ -45,7 +48,6 @@ namespace :bundle do
 					       q.readline = true }
     end
 
-    bundle_version = ENV["version"] || "latest"
     @bundle_name = "bundle-#{bundle_version}.zip"
 
     puts "Downloading and saving #{@bundle_name} to #{measures_dir}"


### PR DESCRIPTION
With the recent changes to the new demo server there is no longer a
"bundle-latest.zip" file. Instead we are using the year of the bundle,
i.e. "bundle-2016.zip".

This change enforces the need to supply the version via `ENV.fetch`
which will now throw an exception if not supplied.

Fixes #426
