### PR TITLE
QRDA Cat III v1.1 uses IPOP instead of IPP all other population codes…

### DIFF
--- a/templates/cat3/_measure_data.cat3.erb
+++ b/templates/cat3/_measure_data.cat3.erb
@@ -121,9 +121,10 @@
        if payer_supplimental_data.present?
          payer_supplimental_data.each do |payer, count| -%>
 
- <!--         PAYER Supplemental Data Reporting   for<%= population.type %>  <%= population.id %>   -->        
+ <!--         PAYER Supplemental Data Reporting   for<%= population.type %>  <%= population.id %>   -->
+ <% payer_templates_ids = qrda3_version == 'r1_1' ? ['2.16.840.1.113883.10.20.27.3.9'] : ['2.16.840.1.113883.10.20.27.3.9', '2.16.840.1.113883.10.20.24.3.55'] %>
  <%== render :partial => 'supplemental_data', :locals => {:template_name => 'Payer Supplemental Data', 
-                :template_ids => ['2.16.840.1.113883.10.20.27.3.9', '2.16.840.1.113883.10.20.24.3.55'], :supplemental_data_code => '48768-6',
+                :template_ids => payer_templates_ids, :supplemental_data_code => '48768-6',
                 :supplemental_data_code_system => '2.16.840.1.113883.6.1', :supplemental_data_value_code => payer,
                 :supplemental_data_value_code_system => '2.16.840.1.113883.3.221.5', :count => count, :qrda3_version => qrda3_version} %>   
       <% end -%>

--- a/templates/cat3/_measure_data.cat3.erb
+++ b/templates/cat3/_measure_data.cat3.erb
@@ -8,10 +8,10 @@
         displayName="Assertion" 
         codeSystemName="ActCode"/>
   <statusCode code="completed"/>
-  <% if qrda3_version == 'r1_1' && population.type == 'IPP' %>
-    <value xsi:type="CD" code="IPOP" 
-           codeSystem="2.16.840.1.113883.5.1063"  
-           codeSystemName="ObservationValue"/>
+  <% if qrda3_version == 'r1_1' %>
+    <value xsi:type="CD" code="<%= population.type == 'IPP' ? 'IPOP' : population.type %>"
+           codeSystem="2.16.840.1.113883.5.4"  
+           codeSystemName="ActCode"/>
   <% else %>
     <value xsi:type="CD" code="<%= population.type %>" 
            codeSystem="2.16.840.1.113883.5.1063"  

--- a/templates/cat3/_measure_data.cat3.erb
+++ b/templates/cat3/_measure_data.cat3.erb
@@ -8,9 +8,15 @@
         displayName="Assertion" 
         codeSystemName="ActCode"/>
   <statusCode code="completed"/>
-  <value xsi:type="CD" code="<%= population.type %>" 
-         codeSystem="2.16.840.1.113883.5.1063"  
-         codeSystemName="ObservationValue"/>
+  <% if qrda3_version == 'r1_1' && population.type == 'IPP' %>
+    <value xsi:type="CD" code="IPOP" 
+           codeSystem="2.16.840.1.113883.5.1063"  
+           codeSystemName="ObservationValue"/>
+  <% else %>
+    <value xsi:type="CD" code="<%= population.type %>" 
+           codeSystem="2.16.840.1.113883.5.1063"  
+           codeSystemName="ObservationValue"/>
+  <% end %>
   <!-- Aggregate Count -->
   <entryRelationship typeCode="SUBJ" inversionInd="true">
     <observation classCode="OBS" moodCode="EVN">

--- a/templates/cat3/_supplemental_data.cat3.erb
+++ b/templates/cat3/_supplemental_data.cat3.erb
@@ -10,10 +10,12 @@
       <code code="<%= supplemental_data_code %>" 
             codeSystem="<%= supplemental_data_code_system %>"/>
       <statusCode code="completed"/>
+      <% if qrda3_version == 'r1' && template_name == 'Payer Supplemental Data' %>
       <effectiveTime>
         <low nullFlavor="NA"/>
         <high nullFlavor="NA"/>
       </effectiveTime>
+      <% end %>
       <% if supplemental_data_value_code == "" || supplemental_data_value_code == "UNK" -%>
       <value xsi:type="CD" 
              nullFlavor="UNK" />

--- a/templates/cat3/show.cat3.erb
+++ b/templates/cat3/show.cat3.erb
@@ -10,7 +10,7 @@
   -->
   <realmCode code="US"/>
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
-  <!-- QRDA Category III Release 1 template ID (this template ID differs from QRDA III comment only template ID). -->
+  <!-- QRDA Category III template ID (this template ID differs from QRDA III comment only template ID). -->
   <templateId root="2.16.840.1.113883.10.20.27.1.1" <% if qrda3_version == 'r1_1' %>extension="2016-02-01"<%end%>/>
   <%== render :partial=>"id", :locals=>{identifier: header.identifier} %>
 


### PR DESCRIPTION
… are the same
