### PR TITLE
Do not save the bundle if it did not successfully import

### DIFF
--- a/lib/health-data-standards/import/bundle/importer.rb
+++ b/lib/health-data-standards/import/bundle/importer.rb
@@ -64,8 +64,11 @@ module HealthDataStandards
 
           return bundle
         ensure
-          bundle.done_importing = true unless bundle.nil?
-          bundle.save
+          # If the bundle is nil or the bundle has never been saved then do not set done_importing or run save.
+          if bundle && bundle.created_at
+            bundle.done_importing = true
+            bundle.save
+          end
         end
 
 


### PR DESCRIPTION
Currently if you import a bundle and it fails because the same version already exists in the database, then the ensure block is still run and the bundle is still saved, leaving 2 records for the same bundle in the database. This adds a check to see if the bundle was ever saved in the first place before running bundle.save again. This issue can be seen now by accessing the cypress bundle import admin page and uploading the same bundle twice.