### PR TITLE
oid_for_code now returns vs_oid even if the code is the 0th element in the oid_map

### DIFF
--- a/lib/health-data-standards/export/helper/cat1_view_helper.rb
+++ b/lib/health-data-standards/export/helper/cat1_view_helper.rb
@@ -52,7 +52,7 @@ module HealthDataStandards
           valueset_oids.each do |vs_oid|
             oid_list = (vs_map[vs_oid] || [])
             oid_map = Hash[oid_list.collect{|x| [x["set"],x["values"]]}]
-            if ((oid_map[code_system] || []).index code).nil?
+            if (oid_map[code_system] || []).include? code
               return vs_oid
             end
           end

--- a/lib/health-data-standards/export/helper/cat1_view_helper.rb
+++ b/lib/health-data-standards/export/helper/cat1_view_helper.rb
@@ -52,7 +52,7 @@ module HealthDataStandards
           valueset_oids.each do |vs_oid|
             oid_list = (vs_map[vs_oid] || [])
             oid_map = Hash[oid_list.collect{|x| [x["set"],x["values"]]}]
-            if (oid_map[code_system] || []).index code
+            if ((oid_map[code_system] || []).index code).nil?
               return vs_oid
             end
           end


### PR DESCRIPTION
Change condition to check if index returns nil so that it does not evalute to false when code is at index 0