### PR TITLE
This stores/sets the negated/non-negated hqmf_oid by checking negation_ind=true while importing

### DIFF
--- a/lib/health-data-standards/import/cat1/entry_package.rb
+++ b/lib/health-data-standards/import/cat1/entry_package.rb
@@ -13,12 +13,24 @@ module HealthDataStandards
 
         def package_entries (doc, nrh)
           entries = self.importer_type.create_entries(doc, nrh)
-          entries.each do |entry| 
-            entry.oid = self.hqmf_oid
+          entries.each do |entry|
+            # This stores/sets the negated/non-negated hqmf_oid by checking negation_ind=true(This caused errors while Cypress testing)
+            # This will thus handle proper matching while looking for entries and later the exporting of proper entries/templates
+            # It supposes We keep non-negated hqmf_oid as default in patient importer for different sections (in lib/health-data-standards/import/cat1/patient_importer.rb)
+            entry.oid = entry.negation_ind ? negate_oid(self.hqmf_oid) : self.hqmf_oid
             entry.status = self.status
           end          
           entries
         end
+
+        # This changes the last part of hqmf_oid to negate it by adding 100 to it
+        # Example: 2.16.840.1.113883.3.560.1.6 will be changed to its negation 2.16.840.1.113883.3.560.1.106
+        def negate_oid(hqmf_oid)
+          neg_hqmf_oid = hqmf_oid.sub(/\d+\Z/) {|x| x.to_i + 100}
+          HealthDataStandards.logger.warn("Negation of #{hqmf_oid} is #{neg_hqmf_oid} has been set")
+          neg_hqmf_oid
+        end
+
       end
     end
   end

--- a/lib/health-data-standards/import/cat1/patient_importer.rb
+++ b/lib/health-data-standards/import/cat1/patient_importer.rb
@@ -35,7 +35,7 @@ module HealthDataStandards
                                               generate_importer(ImmunizationAdministeredImporter, nil, '2.16.840.1.113883.10.20.28.3.112', 'administered')] #immunization
           @section_importers[:communications] = [generate_importer(CDA::CommunicationImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.3']", '2.16.840.1.113883.3.560.1.31'), #comm from provider to patient
                                                  generate_importer(CDA::CommunicationImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.2']", '2.16.840.1.113883.3.560.1.30'), #comm from patient to provider
-                                                 generate_importer(CDA::CommunicationImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.4']", '2.16.840.1.113883.3.560.1.129')] #comm from provider to provider, not done
+                                                 generate_importer(CDA::CommunicationImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.4']", '2.16.840.1.113883.3.560.1.29')] #comm from provider to provider done
           @section_importers[:procedures] = [generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.59']", '2.16.840.1.113883.3.560.1.57', 'performed'), #physical exam performed
                                              generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.31']", '2.16.840.1.113883.3.560.1.45', 'ordered'), #intervention ordered
                                              generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.32']", '2.16.840.1.113883.3.560.1.46', 'performed'), #intervention performed
@@ -44,7 +44,7 @@ module HealthDataStandards
                                              generate_importer(ProcedurePerformedImporter, "./cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.64']", '2.16.840.1.113883.3.560.1.6'),
                                              generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.66']", '2.16.840.1.113883.3.560.1.63'),
                                              generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.69']", '2.16.840.1.113883.3.560.1.21'), #risk category assessment
-                                             generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.18']", '2.16.840.1.113883.3.560.1.103', 'performed'), #diagnostic study performed
+                                             generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.18']", '2.16.840.1.113883.3.560.1.3', 'performed'), #diagnostic study performed
                                              generate_importer(CDA::ProcedureImporter, "./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.20']", '2.16.840.1.113883.3.560.1.11'), #diagnostic study result
                                              generate_importer(DiagnosticStudyOrderImporter, nil, '2.16.840.1.113883.3.560.1.40', 'ordered')]
 


### PR DESCRIPTION
This stores/sets the negated/non-negated hqmf_oid by checking negation_ind=true(This caused errors while Cypress testing)
-  Fixes issues related to this issue: https://github.com/projectcypress/health-data-standards/issues/333 
- This will thus handle proper matching while looking for entries and later the exporting of proper entries/templates
- It supposes We keep non-negated hqmf_oid as default in patient importer for different sections (in lib/health-data-standards/import/cat1/patient_importer.rb)
- This changes the last part of hqmf_oid to negate it by adding 100 to it
- Example: 2.16.840.1.113883.3.560.1.6 will be changed to its negation 2.16.840.1.113883.3.560.1.106