### PR TITLE
HQMF parser now preserves the full HQMF eMeasure version number

### DIFF
--- a/lib/hqmf-parser/2.0/document.rb
+++ b/lib/hqmf-parser/2.0/document.rb
@@ -114,7 +114,7 @@ module HQMF2
             attr_val('cda:QualityMeasureDocument/cda:id/@root').upcase
       @hqmf_set_id = attr_val('cda:QualityMeasureDocument/cda:setId/@extension') ||
                      attr_val('cda:QualityMeasureDocument/cda:setId/@root').upcase
-      @hqmf_version_number = attr_val('cda:QualityMeasureDocument/cda:versionNumber/@value').to_i
+      @hqmf_version_number = attr_val('cda:QualityMeasureDocument/cda:versionNumber/@value')
 
       # TODO: -- figure out if this is the correct thing to do -- probably not, but is
       # necessary to get the bonnie comparison to work.  Currently
@@ -181,7 +181,7 @@ module HQMF2
       value_obj = handle_attribute_value(attribute, value) if attribute.at_xpath('./cda:value', NAMESPACES)
 
       # Handle the cms_id
-      @cms_id = "CMS#{value}v#{@hqmf_version_number}" if name.include? 'eMeasure Identifier'
+      @cms_id = "CMS#{value}v#{@hqmf_version_number.to_i}" if name.include? 'eMeasure Identifier'
 
       HQMF::Attribute.new(id, code, value, nil, name, id_obj, code_obj, value_obj)
     end

--- a/test/unit/hqmf/2.0/hqmf_vs_simple_test.rb
+++ b/test/unit/hqmf/2.0/hqmf_vs_simple_test.rb
@@ -82,6 +82,9 @@ class HQMFVsSimpleTest < Minitest::Test
     # rebuild hqmf model so that source data criteria are different objects
     hqmf_model = HQMF::Document.from_json(JSON.parse(hqmf_model.to_json.to_json, max_nesting: 100))
 
+    # Only care about the major hqmf version id for the comparison test
+    hqmf_model.instance_variable_set(:@hqmf_version_number, hqmf_model.hqmf_version_number.to_i)
+
     simple_xml = File.join(SIMPLE_XML_ROOT, "#{measure_name}_SimpleXML.xml")
     simple_xml_model = SimpleXml::Parser::V1Parser.new.parse(File.read(simple_xml))
 


### PR DESCRIPTION
the HQMF file now have finer granularity for version numbers (e.g. 5.1.000). With the Measure History View in Bonnie, this will be helpful for the users to differentiate between uploads of the same version of the measure. To capture this, the version should be stored as a string rather than an integer.