### PR TITLE
Change condition that checks if code_system exists

### DIFF
--- a/lib/health-data-standards/export/helper/cat1_view_helper.rb
+++ b/lib/health-data-standards/export/helper/cat1_view_helper.rb
@@ -52,7 +52,7 @@ module HealthDataStandards
           valueset_oids.each do |vs_oid|
             oid_list = (vs_map[vs_oid] || [])
             oid_map = Hash[oid_list.collect{|x| [x["set"],x["values"]]}]
-            if (oid_map[code_system] || []).include? code
+            if ((oid_map[code_system] || []).index code).nil?
               return vs_oid
             end
           end


### PR DESCRIPTION
Change condition that checks if code_system exists to return true if code_system is in the 0th location

Previous logic used just .include which returns index of code_system in map, if the index is 0 the logic evaluates to false. I changed the logic to check if the .include call returns nil instead