### PR TITLE
several displayed descriptions for data criteria needed to change to …

### DIFF
--- a/test/unit/hqmf/model/data_criteria_test.rb
+++ b/test/unit/hqmf/model/data_criteria_test.rb
@@ -16,11 +16,12 @@ module HQMFModel
         mismatches << field_title unless field == title
       end
 
-      # ignore custom fulfills and previous ordinal field values
-      mismatches -= ["FLFS - FULFILLS", "ORDINAL - ORDINALITY"]
-
-      # ignore changes needed when converting to qdm 5.0
-      mismatches -= [
+      
+      expected_mismatches = [
+        # ignore custom fulfills and previous ordinal field values
+        "FLFS - FULFILLS",
+        "ORDINAL - ORDINALITY",
+        # the following represent display name changes that were necessary for the QDM 5.0 update
         "DISCHARGE_STATUS - DISCHARGE_DISPOSITION",
         "DOSE - DOSAGE",
         "FACILITY_LOCATION_ARRIVAL_DATETIME - LOCATION_PERIOD_START_DATETIME",
@@ -28,9 +29,7 @@ module HQMFModel
         "REFERENCE_RANGE_HIGH - REFERENCE_RANGE_-_HIGH",
         "REFERENCE_RANGE_LOW - REFERENCE_RANGE_-_LOW"
       ]
-
-      assert mismatches.empty?, "Mismatches found: #{mismatches}."
-
+      assert_equal mismatches.sort, expected_mismatches.sort
     end
 
     def test_value_fields

--- a/test/unit/hqmf/model/data_criteria_test.rb
+++ b/test/unit/hqmf/model/data_criteria_test.rb
@@ -19,6 +19,16 @@ module HQMFModel
       # ignore custom fulfills and previous ordinal field values
       mismatches -= ["FLFS - FULFILLS", "ORDINAL - ORDINALITY"]
 
+      # ignore changes needed when converting to qdm 5.0
+      mismatches -= [
+        "DISCHARGE_STATUS - DISCHARGE_DISPOSITION",
+        "DOSE - DOSAGE",
+        "FACILITY_LOCATION_ARRIVAL_DATETIME - LOCATION_PERIOD_START_DATETIME",
+        "FACILITY_LOCATION_DEPARTURE_DATETIME - LOCATION_PERIOD_END_DATETIME",
+        "REFERENCE_RANGE_HIGH - REFERENCE_RANGE_-_HIGH",
+        "REFERENCE_RANGE_LOW - REFERENCE_RANGE_-_LOW"
+      ]
+
       assert mismatches.empty?, "Mismatches found: #{mismatches}."
 
     end


### PR DESCRIPTION
…conform with QDM 5.0 changes. However, the codes themselves seemed like they should stay the same for backwards compatibility. this led to discrepencies in the testing. these are addressed in this pull request.