### PR TITLE
Now capturing missing referenced data criteria ids in the HQMF parser

### DIFF
--- a/lib/hqmf-parser/2.0/document.rb
+++ b/lib/hqmf-parser/2.0/document.rb
@@ -78,6 +78,17 @@ module HQMF2
       find(@data_criteria, :local_variable_name, local_variable_name)
     end
 
+    # Get ids of data criteria directly referenced by others
+    # @return [Array] an array of ids of directly referenced data criteria
+    def all_reference_ids
+      @reference_ids
+    end
+
+    # Adds id of a data criteria to the list of reference ids
+    def add_reference_id(id)
+      @reference_ids << id
+    end
+
     # Parse an XML document from the supplied contents
     # @return [Nokogiri::XML::Document]
     def self.parse(hqmf_contents)

--- a/lib/hqmf-parser/2.0/document_helpers/doc_utilities.rb
+++ b/lib/hqmf-parser/2.0/document_helpers/doc_utilities.rb
@@ -67,7 +67,8 @@ module HQMF2
 
       base_criteria_defs = %w(patient_characteristic_ethnicity patient_characteristic_gender patient_characteristic_payer patient_characteristic_race)
       to_reject = true
-      to_reject &&= @reference_ids.index(dc.id).nil? # don't reject if anything refers directly to this criteria
+      # don't reject if anything refers directly to this criteria
+      to_reject &&= @reference_ids.index(dc.id).nil?
       # don't reject if it is a "base" criteria (no references but must exist)
       to_reject &&= !base_criteria_defs.include?(dc.definition)
       # keep referral occurrence
@@ -126,6 +127,5 @@ module HQMF2
       right = cc_filtered.nil? || cc_filtered.empty? ? nil : cc_filtered.try(:to_json)
       return empty || left == right
     end
-    
   end
 end

--- a/lib/hqmf-parser/2.0/population_criteria.rb
+++ b/lib/hqmf-parser/2.0/population_criteria.rb
@@ -75,6 +75,8 @@ module HQMF2
       parts = exp.to_s.split('-')
       dc = parse_parts_to_dc(parts)
       @doc.add_data_criteria(dc)
+      # Update reference_ids with any newly referenced data criteria
+      dc.children_criteria.each { |cc| @doc.add_reference_id(cc) } unless dc.children_criteria.nil?
       dc
     end
 


### PR DESCRIPTION
Referenced data criteria were not being included in the reference_ids array during HQMF parsing when those data criteria were in fact referenced by observation criteria. This caused the unnecessary removal of data criteria during the filtering phase. When extracting observation criteria, the parser now records any children criteria as referenced, so they will not be removed later in the parsing process.