### PR TITLE
Change Diagnostic Study, Recommended HQMFR1 OID to be correct

### DIFF
--- a/lib/health-data-standards/export/qrda/hqmf-qrda-oids.json
+++ b/lib/health-data-standards/export/qrda/hqmf-qrda-oids.json
@@ -115,7 +115,7 @@
   },
   {
     "hqmf_name": "Diagnostic Study, Recommended",
-    "hqmf_oid": "2.16.840.1.113883.3.560.1.40",
+    "hqmf_oid": "2.16.840.1.113883.10.20.28.3.24",
     "qrda_name": "Diagnostic Study Recommended",
     "qrda_oid": "2.16.840.1.113883.10.20.24.3.19"
   },
@@ -225,7 +225,7 @@
     "hqmf_name": "Intervention, Order",
     "hqmf_oid": "2.16.840.1.113883.3.560.1.45",
     "qrda_name": "Intervention Order",
-    "qrda_oid": "2.16.840.1.113883.10.20.24.3.31"    
+    "qrda_oid": "2.16.840.1.113883.10.20.24.3.31"
   },
   {
     "hqmf_name": "Intervention, Order not done",
@@ -237,7 +237,7 @@
     "hqmf_name": "Intervention, Performed",
     "hqmf_oid": "2.16.840.1.113883.3.560.1.46",
     "qrda_name": "Intervention Performed",
-    "qrda_oid": "2.16.840.1.113883.10.20.24.3.32"  
+    "qrda_oid": "2.16.840.1.113883.10.20.24.3.32"
   },
   {
     "hqmf_name": "Intervention, Recommended",
@@ -429,7 +429,7 @@
     "hqmf_name": "Procedure, Intolerance",
     "hqmf_oid": "2.16.840.1.113883.3.560.1.61",
     "qrda_name": "Procedure Intolerance",
-    "qrda_oid": "2.16.840.1.113883.10.20.24.3.62"  
+    "qrda_oid": "2.16.840.1.113883.10.20.24.3.62"
   },
   {
     "hqmf_name": "Procedure, Order",
@@ -441,7 +441,7 @@
     "hqmf_name": "Procedure, Performed",
     "hqmf_oid": "2.16.840.1.113883.3.560.1.6",
     "qrda_name": "Procedure Performed",
-    "qrda_oid": "2.16.840.1.113883.10.20.24.3.64"  
+    "qrda_oid": "2.16.840.1.113883.10.20.24.3.64"
   },
   {
     "hqmf_name": "Procedure, Recommended",
@@ -501,7 +501,7 @@
     "hqmf_name": "Risk Category Assessment",
     "hqmf_oid": "2.16.840.1.113883.3.560.1.21",
     "qrda_name": "Risk Category Assessment",
-    "qrda_oid": "2.16.840.1.113883.10.20.24.3.69"  
+    "qrda_oid": "2.16.840.1.113883.10.20.24.3.69"
   },
   {
     "hqmf_name": "Severity (attribute)",
@@ -519,7 +519,7 @@
     "hqmf_name": "Substance, Administered",
     "hqmf_oid": "2.16.840.1.113883.3.560.1.64",
     "qrda_name": "Medication Administered",
-    "qrda_oid": "2.16.840.1.113883.10.20.24.3.42"  
+    "qrda_oid": "2.16.840.1.113883.10.20.24.3.42"
   },
   {
     "hqmf_name": "Substance, Adverse Event",
@@ -531,19 +531,19 @@
     "hqmf_name": "Substance, Allergy",
     "hqmf_oid": "2.16.840.1.113883.3.560.1.66",
     "qrda_name": "Medication Allergy",
-    "qrda_oid": "2.16.840.1.113883.10.20.24.3.44"  
+    "qrda_oid": "2.16.840.1.113883.10.20.24.3.44"
   },
   {
     "hqmf_name": "Substance, Intolerance",
     "hqmf_oid": "2.16.840.1.113883.3.560.1.67",
     "qrda_name": "Medication Intolerance",
-    "qrda_oid": "2.16.840.1.113883.10.20.24.3.46"  
+    "qrda_oid": "2.16.840.1.113883.10.20.24.3.46"
   },
   {
     "hqmf_name": "Substance, Order",
     "hqmf_oid": "2.16.840.1.113883.3.560.1.68",
     "qrda_name": "Medication Order",
-    "qrda_oid": "2.16.840.1.113883.10.20.24.3.47"  
+    "qrda_oid": "2.16.840.1.113883.10.20.24.3.47"
   },
   {
     "hqmf_name": "Substance, Recommended",
@@ -579,7 +579,7 @@
     "hqmf_name": "Transfer From (attribute)",
     "hqmf_oid": "2.16.840.1.113883.3.560.1.71",
     "qrda_name": "Transfer From",
-    "qrda_oid": "2.16.840.1.113883.10.20.24.3.81"  
+    "qrda_oid": "2.16.840.1.113883.10.20.24.3.81"
   },
   {
     "hqmf_name": "Transfer To (attribute)",


### PR DESCRIPTION
`Diagnostic Study, Recommended` used to have the same HQMF OID in the map as `Diagnostic Study, Ordered`. This didn't cause issues in HDS, because we have no `Diagnostic Study, Recommended` elements, and `Diagnostic Study, Ordered` comes first in HDS. However, `Go` doesn't respect orderings like this (for precisely this reason), so we were sometimes getting the `Diagnostic Study, Recommended` QRDA OID when we wanted the `Diagnostic Study, Ordered` one. This change changes the HQMF OID to be the correct one, just in case HDS has a `Diagnostic Study, Recommended` entry in the future.