### PR TITLE
Fix support for CV Measures

### DIFF
--- a/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
+++ b/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
@@ -17,18 +17,22 @@ module HQMF2CQL
     def extract_observations
       @observations = []
 
-      # Look for observations in the measureObservationSection of the CQL based HQMF document, and if they exist extract the name of the CQL statement that calculates the observation.
+      # Look for observations in the measureObservationSection of the CQL based HQMF document, and if they exist extract the name of the CQL statement that calculates the observation. This is the name of the "define function" statement in the CQL.
+      # In addition to the function name we also need to retreive the list of the parameters for the function.
       observation_section = @doc.xpath('/cda:QualityMeasureDocument/cda:component/cda:measureObservationSection',
                                        HQMF2::Document::NAMESPACES)
 
       unless observation_section.empty?
         observation_section.each do |entry|
+          cql_define_function = {:function_name => '', :parameter_list => []}
           # The at_xpath(...).values returns an array of a single element.
           # The match returns an array and since we don't want the double quotes we take the second element
-          @observations << entry.at_xpath("*/cda:measureObservationDefinition/cda:value/cda:expression").values.first.match('\\"([A-Za-z0-9 ]+)\\"')[1]
+          cql_define_function[:function_name] = entry.at_xpath("*/cda:measureObservationDefinition/cda:value/cda:expression").values.first.match('\\"([A-Za-z0-9 ]+)\\"')[1]
+          # TODO: Determine whether or not we need to iteriate over the components
+          cql_define_function[:parameter_list] << entry.at_xpath("*/cda:measureObservationDefinition/cda:component/cda:criteriaReference/cda:id").attributes['extension'].value.match('\\"([A-Za-z0-9 ]+)\\"')[1]
+          @observations << cql_define_function
         end
       end
-
       !@observations.empty?
     end
 

--- a/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
+++ b/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
@@ -18,18 +18,17 @@ module HQMF2CQL
       @observations = []
 
       # Look for observations in the measureObservationSection of the CQL based HQMF document, and if they exist extract the name of the CQL statement that calculates the observation. This is the name of the "define function" statement in the CQL.
-      # In addition to the function name we also need to retreive the list of the parameters for the function.
+      # In addition to the function name we also need to retreive the parameter for the function.
       observation_section = @doc.xpath('/cda:QualityMeasureDocument/cda:component/cda:measureObservationSection',
                                        HQMF2::Document::NAMESPACES)
 
       unless observation_section.empty?
         observation_section.each do |entry|
-          cql_define_function = {:function_name => '', :parameter_list => []}
+          cql_define_function = {}
           # The at_xpath(...).values returns an array of a single element.
           # The match returns an array and since we don't want the double quotes we take the second element
           cql_define_function[:function_name] = entry.at_xpath("*/cda:measureObservationDefinition/cda:value/cda:expression").values.first.match('\\"([A-Za-z0-9 ]+)\\"')[1]
-          # TODO: Determine whether or not we need to iteriate over the components
-          cql_define_function[:parameter_list] << entry.at_xpath("*/cda:measureObservationDefinition/cda:component/cda:criteriaReference/cda:id").attributes['extension'].value.match('\\"([A-Za-z0-9 ]+)\\"')[1]
+          cql_define_function[:parameter] = entry.at_xpath("*/cda:measureObservationDefinition/cda:component/cda:criteriaReference/cda:id").attributes['extension'].value.match('\\"([A-Za-z0-9 ]+)\\"')[1]
           @observations << cql_define_function
         end
       end


### PR DESCRIPTION
Updated the way that the observations in Continuous Variable measures are stored.  Based on an deeper understanding of the specs CV measures will have a function (defined in the CQL) and a parameter (defined in the HQMF) that is used for the aggregation.  This pulls these two pieces of information out of the HQMF.