### PR TITLE
reverting 'missing stratifications from HQMF parsing block' change

### DIFF
--- a/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
+++ b/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
@@ -48,8 +48,7 @@ module HQMF2CQL
           HQMF::PopulationCriteria::DENEXCEP => 'denominatorExceptionCriteria',
           HQMF::PopulationCriteria::DENEX => 'denominatorExclusionCriteria',
           HQMF::PopulationCriteria::MSRPOPL => 'measurePopulationCriteria',
-          HQMF::PopulationCriteria::MSRPOPLEX => 'measurePopulationExclusionCriteria',
-          HQMF::PopulationCriteria::STRAT => 'stratifierCriteria'
+          HQMF::PopulationCriteria::MSRPOPLEX => 'measurePopulationExclusionCriteria'
         }.each_pair do |criteria_id, criteria_element_name|
           criteria_def = population_def.at_xpath("cda:#{criteria_element_name}", HQMF2::Document::NAMESPACES)
           if criteria_def


### PR DESCRIPTION
And we thought we had fixed stratification. LOL. This change will be reintroduced in a better fashion in another pull request. Sorry we went down a dead-end.