### PR TITLE
MAT 5.3 changed mime type for CQL measures

### DIFF
--- a/lib/hqmf-parser/parser.rb
+++ b/lib/hqmf-parser/parser.rb
@@ -52,6 +52,10 @@ module HQMF
         doc = HQMF2::Document.parse(xml_contents)
         hqmf2 = !doc.at_xpath("/cda:QualityMeasureDocument/cda:typeId[@root='2.16.840.1.113883.1.3' and @extension='POQM_HD000001UV02']").nil?
         cql = !doc.at_xpath("/cda:QualityMeasureDocument/cda:relatedDocument/cda:expressionDocument/cda:text[@mediaType='application/cql']").nil?
+        if !cql
+          # The media type changed for MAT version 5.3
+          cql = !doc.at_xpath("/cda:QualityMeasureDocument/cda:relatedDocument/cda:expressionDocument/cda:text[@mediaType='text/cql']").nil?
+        end
         hqmf2 && cql
       end
 


### PR DESCRIPTION
This is one of several fixes that are required to load a measure exported with the MAT 5.3.

Related to: https://jira.mitre.org/browse/BONNIE-766
JIRA test: https://jira.mitre.org/browse/BONNIE-772
_(Note: to test you must modify your bonnie Gemfile to point to this HDS branch)_

The mime types now supported are: "application/cql" and "text/cql". Either can be used, for backwards compatibility.