### PR TITLE
Add a CCN getter/setter to Provider

### DIFF
--- a/lib/health-data-standards/models/provider.rb
+++ b/lib/health-data-standards/models/provider.rb
@@ -2,9 +2,10 @@ class Provider
   include Personable
   include Mongoid::Tree
   include Mongoid::Attributes::Dynamic
-  
+
   NPI_OID = '2.16.840.1.113883.4.6'
   TAX_ID_OID = '2.16.840.1.113883.4.2'
+  CCN_OID = '2.16.840.1.113883.4.336'.freeze
 
   field :specialty   , type: String
   field :phone       , type: String
@@ -38,6 +39,21 @@ class Provider
   def tin
     cda_id_tin = self.cda_identifiers.where(root: TAX_ID_OID).first
     cda_id_tin ? cda_id_tin.extension : nil
+  end
+
+  def ccn=(a_ccn)
+    cda_id_ccn = self.cda_identifiers.where(root: CCN_OID).first
+    if cda_id_ccn
+      cda_id_ccn.extension = a_ccn
+      cda_id_ccn.save!
+    else
+      self.cda_identifiers << CDAIdentifier.new(root: CCN_OID, extension: a_ccn)
+    end
+  end
+
+  def ccn
+    cda_id_ccn = self.cda_identifiers.where(root: CCN_OID).first
+    cda_id_ccn ? cda_id_ccn.extension : nil
   end
 
   def records(effective_date=nil)

--- a/test/unit/models/provider_test.rb
+++ b/test/unit/models/provider_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class ProviderTest < Minitest::Test
-  
+
   def test_valid_npi_value
     assert_equal "3", Provider.luhn_checksum('7992739871')
     assert Provider.valid_npi?('1234567893')
@@ -19,5 +19,16 @@ class ProviderTest < Minitest::Test
     p.npi = '808401234567893'
     assert_equal 1, p.cda_identifiers.length
     assert_equal '808401234567893', p.npi
+  end
+
+  def test_ccn_assignment
+    # A provider should only have a single CCN
+    p = Provider.new
+    p.ccn = '123456'
+    assert_equal 1, p.cda_identifiers.length
+    p.ccn = '800890'
+    assert_equal 1, p.cda_identifiers.length
+    assert_equal '800890', p.ccn
+    assert_equal '2.16.840.1.113883.4.336', p.cda_identifiers.first.root
   end
 end


### PR DESCRIPTION
CCN should be stored with the Provider so we can output it into the Cat I without hardcoding it into the template. This adds code to do that.