### PR TITLE
made tests work

### DIFF
--- a/lib/hqmf-parser/2.0/document_helpers/doc_population_helper.rb
+++ b/lib/hqmf-parser/2.0/document_helpers/doc_population_helper.rb
@@ -126,8 +126,6 @@ module HQMF2
         stratified_population['id'] = id_def ? "#{id_def.value} - Stratification #{criteria_def_index + 1}" : "Population#{index}"
         title_def = population_def.at_xpath('cda:title/@value', HQMF2::Document::NAMESPACES)
         stratified_population['title'] = title_def ? "#{title_def.value} - Stratification #{criteria_def_index + 1}" : "Population #{index}"
-        stratified_population['population_index'] = population_index
-        stratified_population['stratification_index'] = criteria_def_index
         @stratifications << stratified_population
       end
     end

--- a/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
+++ b/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
@@ -47,6 +47,33 @@ module HQMF2CQL
       !@observations.empty?
     end
 
+    # Generate the stratifications of populations, if any exist
+    # for CQL, adds 'population_index' and 'stratification_index'
+    def handle_stratifications(population_def, number_of_populations, population, id_def, population_index)
+      # handle stratifications (EP137, EP155)
+      stratifier_criteria_xpath = "cda:component/cda:stratifierCriteria[not(cda:component/cda:measureAttribute/cda:code[@code  = 'SDE'])]/.."
+      population_def.xpath(stratifier_criteria_xpath, HQMF2::Document::NAMESPACES)
+        .each_with_index do |criteria_def, criteria_def_index|
+        # Skip this Stratification if any precondition doesn't contain any preconditions
+        next unless PopulationCriteria.new(criteria_def, @document, @id_generator)
+                    .preconditions.all? { |prcn| prcn.preconditions.length > 0 }
+        index = number_of_populations + ((population_index - 1) * criteria_def.xpath('./*/cda:precondition').length) +
+                criteria_def_index
+        criteria_id = HQMF::PopulationCriteria::STRAT
+        stratified_population = population.dup
+        stratified_population['stratification'] = criteria_def.at_xpath('./*/cda:id/@root').try(:value) ||
+                                                  "#{criteria_id}-#{criteria_def_index}"
+        build_population_criteria(criteria_def, criteria_id, stratified_population)
+
+        stratified_population['id'] = id_def ? "#{id_def.value} - Stratification #{criteria_def_index + 1}" : "Population#{index}"
+        title_def = population_def.at_xpath('cda:title/@value', HQMF2::Document::NAMESPACES)
+        stratified_population['title'] = title_def ? "#{title_def.value} - Stratification #{criteria_def_index + 1}" : "Population #{index}"
+        stratified_population['population_index'] = population_index
+        stratified_population['stratification_index'] = criteria_def_index
+        @stratifications << stratified_population
+      end
+    end
+
     # Extracts the mappings between actual HQMF populations and their
     # corresponding CQL define statements.
     def extract_populations_cql_map

--- a/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
+++ b/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
@@ -55,7 +55,7 @@ module HQMF2CQL
       population_def.xpath(stratifier_criteria_xpath, HQMF2::Document::NAMESPACES)
         .each_with_index do |criteria_def, criteria_def_index|
         # Skip this Stratification if any precondition doesn't contain any preconditions
-        next unless PopulationCriteria.new(criteria_def, @document, @id_generator)
+        next unless HQMF2::PopulationCriteria.new(criteria_def, @document, @id_generator)
                     .preconditions.all? { |prcn| prcn.preconditions.length > 0 }
         index = number_of_populations + ((population_index - 1) * criteria_def.xpath('./*/cda:precondition').length) +
                 criteria_def_index

--- a/test/unit/hqmf/2.0/hqmf_vs_simple_test.rb
+++ b/test/unit/hqmf/2.0/hqmf_vs_simple_test.rb
@@ -187,10 +187,6 @@ class HQMFVsSimpleTest < Minitest::Test
     #  or is superfluous in HQMF (they both contain "STRAT"s)
     hqmf_model.instance_variable_get(:@populations).map! { |pop| pop.reject { |key, _value| key == 'stratification' } }
 
-    # the population_index and stratification_index were added to support CQL work and do not affect QDM-based measures
-    hqmf_model.instance_variable_get(:@populations).map! { |pop| pop.reject { |key, _value| key == 'population_index' } }
-    hqmf_model.instance_variable_get(:@populations).map! { |pop| pop.reject { |key, _value| key == 'stratification_index' } }
-
     # population titles in HQMF2 can be ignored
     hqmf_model.instance_variable_get(:@populations).map! { |pop| pop.reject { |key, _value| key == 'title' } }
     simple_xml_model.instance_variable_get(:@populations).map! { |pop| pop.reject { |key, _value| key == 'title' } }

--- a/test/unit/hqmf/2.0/hqmf_vs_simple_test.rb
+++ b/test/unit/hqmf/2.0/hqmf_vs_simple_test.rb
@@ -187,6 +187,10 @@ class HQMFVsSimpleTest < Minitest::Test
     #  or is superfluous in HQMF (they both contain "STRAT"s)
     hqmf_model.instance_variable_get(:@populations).map! { |pop| pop.reject { |key, _value| key == 'stratification' } }
 
+    # the population_index and stratification_index were added to support CQL work and do not affect QDM-based measures
+    hqmf_model.instance_variable_get(:@populations).map! { |pop| pop.reject { |key, _value| key == 'population_index' } }
+    hqmf_model.instance_variable_get(:@populations).map! { |pop| pop.reject { |key, _value| key == 'stratification_index' } }
+
     # population titles in HQMF2 can be ignored
     hqmf_model.instance_variable_get(:@populations).map! { |pop| pop.reject { |key, _value| key == 'title' } }
     simple_xml_model.instance_variable_get(:@populations).map! { |pop| pop.reject { |key, _value| key == 'title' } }


### PR DESCRIPTION
CQL-related functionality was removed from the hqfm 2.0 parsing code and into the cql parsing code.

This should be tested with this JIRA test to confirm that CQL imports still work: BONNIE-856
(there may be a shorter test for this).

Internal ticket: BONNIE-873