### PR TITLE
added missing templates

### DIFF
--- a/lib/hqmf-parser/cql/value_set_helper.rb
+++ b/lib/hqmf-parser/cql/value_set_helper.rb
@@ -90,7 +90,9 @@ module HQMF2CQL
       '2.16.840.1.113883.10.20.28.4.115' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role/cda:playingMaterial[@classCode='MMAT']/cda:code", result_path: nil },
       '2.16.840.1.113883.10.20.28.4.116' => { valueset_path: './*/cda:value', result_path: nil },
       '2.16.840.1.113883.10.20.28.4.117' => { valueset_path: './*/cda:code', result_path: './*/cda:value' },
-      '2.16.840.1.113883.10.20.28.4.118' => { valueset_path: './*/cda:code', result_path: nil }
+      '2.16.840.1.113883.10.20.28.4.118' => { valueset_path: './*/cda:code', result_path: nil },
+      '2.16.840.1.113883.10.20.28.4.119' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='MANU']/cda:playingEntity[@classCode='MMAT']/cda:code", result_path: nil },
+      '2.16.840.1.113883.10.20.28.4.120' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='MANU']/cda:playingEntity[@classCode='MMAT']/cda:code", result_path: nil }
     }
     # rubocop:enable Metrics/LineLength
 


### PR DESCRIPTION
There are new templates that were previously added to the qdm value_set_helper file that never made it into this file. This made it so a new data criteria type (allergy/intollerance) didn't have a value set associated with it.

JIRA test: https://jira.mitre.org/browse/BONNIE-993