### PR TITLE
BONNIE-1072 VSAC Call Changes

### DIFF
--- a/lib/health-data-standards/util/vs_api.rb
+++ b/lib/health-data-standards/util/vs_api.rb
@@ -59,8 +59,6 @@ module HealthDataStandards
       # The VSAC V2 API needs a profile to be specified when using includeDraft. Future work on this 
       # class could include a function to fetch the list of profiles from the https://vsac.nlm.nih.gov/vsac/profiles
       # call.
-      DEFAULT_PROFILE = "Most Recent CS Versions"
-      
       def initialize(ticket_url, api_url, username, password, ticket_granting_ticket = nil)
         super(ticket_url, api_url, username, password, ticket_granting_ticket)
       end
@@ -71,7 +69,7 @@ module HealthDataStandards
         profile = options.fetch(:profile, nil)
         effective_date = options.fetch(:effective_date, nil)
         program_name = options.fetch(:program, nil)
-        if profile.nil? && include_draft
+        if (profile.nil? || profile.empty?) && include_draft
           raise MalformedVSQueryError, "Include Draft Specified, no Profile provided"
         end
         params = { id: oid, ticket: get_ticket }

--- a/lib/health-data-standards/util/vs_api.rb
+++ b/lib/health-data-standards/util/vs_api.rb
@@ -4,6 +4,8 @@ module HealthDataStandards
   module Util
     class VSNotFoundError < StandardError
     end
+    class MalformedVSQueryError < StandardError
+    end
 
     class VSApi
       attr_accessor :api_url, :ticket_url, :username, :password
@@ -69,6 +71,9 @@ module HealthDataStandards
         profile = options.fetch(:profile, nil)
         effective_date = options.fetch(:effective_date, nil)
         program_name = options.fetch(:program, nil)
+        if profile.nil? && include_draft
+          raise MalformedVSQueryError, "Include Draft Specified, no Profile provided"
+        end
         params = { id: oid, ticket: get_ticket }
         params[:version] = version if version
         params[:includeDraft] = 'yes' if profile && include_draft

--- a/lib/health-data-standards/util/vs_api.rb
+++ b/lib/health-data-standards/util/vs_api.rb
@@ -55,7 +55,6 @@ module HealthDataStandards
 
     class VSApiV2 < VSApi
       
-      # This default profile is used when the include_draft option is true without a profile specified.
       # The VSAC V2 API needs a profile to be specified when using includeDraft. Future work on this 
       # class could include a function to fetch the list of profiles from the https://vsac.nlm.nih.gov/vsac/profiles
       # call.

--- a/test/unit/util/vs_api_test.rb
+++ b/test/unit/util/vs_api_test.rb
@@ -31,19 +31,15 @@ class VSApiTest < Minitest::Test
       unless valueset_xml_version[valueset_xml[0]] == ""
         stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket", :effectiveDate=>valueset_xml_version[valueset_xml[0]]}).to_return(:body=>valueset_xml_by_date[valueset_xml[0]])
         assert_equal valueset_xml_by_date[valueset_xml[0]], api.get_valueset("oid", valueset_xml_version[valueset_xml[0]])
-        api.get_valueset("oid", valueset_xml_version[valueset_xml[0]]) do |oid,vs|
-          assert_equal "oid", oid
-          assert_equal valueset_xml_by_date[valueset_xml[0]], vs
-        end
+        vs_call_1 = api.get_valueset("oid", valueset_xml_version[valueset_xml[0]])
+        assert_equal valueset_xml_by_date[valueset_xml[0]], vs_call_1
       end
 
       if valueset_xml_version[valueset_xml[0]] == ""
         stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket"}).to_return(:body=>valueset_xml_by_date[valueset_xml[0]])
         assert_equal valueset_xml_by_date[valueset_xml[0]], api.get_valueset("oid")
-        api.get_valueset("oid") do |oid,vs|
-          assert_equal "oid", oid
-          assert_equal valueset_xml_by_date[valueset_xml[0]], vs
-        end
+        vs_call_2 = api.get_valueset("oid")
+        assert_equal valueset_xml_by_date[valueset_xml[0]], vs_call_2
       end
     end
 	end
@@ -53,10 +49,8 @@ class VSApiTest < Minitest::Test
     valueset_xml = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23" version="#{ valueset_xml_version }"></ValueSet></RetrieveValueSetResponse>}
     stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket" ,:version => valueset_xml_version}).to_return(:body=>valueset_xml)
     api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
-    api.get_valueset("oid", version: valueset_xml_version) do |oid,vs|
-      assert_equal "oid", oid
-      assert_equal valueset_xml, vs
-    end
+    vs = api.get_valueset("oid", version: valueset_xml_version)
+    assert_equal valueset_xml, vs
   end
   
   def test_api_v2_with_include_draft_default_profile
@@ -64,10 +58,8 @@ class VSApiTest < Minitest::Test
     stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket", :includeDraft=>"yes", :profile=>"Most Recent CS Versions"}).to_return(:body=>valueset_xml)
     api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
     # does not raise HealthDataStandards::Util::MalformedVSQueryError
-    api.get_valueset("oid", include_draft: true, :profile=>"Most Recent CS Versions") do |oid,vs|
-      assert_equal "oid", oid
-      assert_equal valueset_xml, vs
-    end
+    vs = api.get_valueset("oid", include_draft: true, :profile=>"Most Recent CS Versions")
+    assert_equal valueset_xml, vs
   end
   
   def test_api_v2_with_include_draft_no_profile
@@ -84,10 +76,8 @@ class VSApiTest < Minitest::Test
     valueset_xml = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23" version="Draft"></ValueSet></RetrieveValueSetResponse>}
     stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket", :includeDraft=>"yes", :profile=>"Test Profile"}).to_return(:body=>valueset_xml)
     api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
-    api.get_valueset("oid", include_draft: true, profile: "Test Profile") do |oid,vs|
-      assert_equal "oid", oid
-      assert_equal valueset_xml, vs
-    end
+    vs = api.get_valueset("oid", include_draft: true, profile: "Test Profile")
+    assert_equal valueset_xml, vs
   end
 
   def test_api_v2

--- a/test/unit/util/vs_api_test.rb
+++ b/test/unit/util/vs_api_test.rb
@@ -63,6 +63,7 @@ class VSApiTest < Minitest::Test
     valueset_xml = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23" version="Draft"></ValueSet></RetrieveValueSetResponse>}
     stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket", :includeDraft=>"yes", :profile=>"Most Recent CS Versions"}).to_return(:body=>valueset_xml)
     api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
+    # does not raise HealthDataStandards::Util::MalformedVSQueryError
     api.get_valueset("oid", include_draft: true, :profile=>"Most Recent CS Versions") do |oid,vs|
       assert_equal "oid", oid
       assert_equal valueset_xml, vs

--- a/test/unit/util/vs_api_test.rb
+++ b/test/unit/util/vs_api_test.rb
@@ -70,10 +70,13 @@ class VSApiTest < Minitest::Test
   end
   
   def test_api_v2_with_include_draft_no_profile
-    api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
+    valueset_xml = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23" version="Draft"></ValueSet></RetrieveValueSetResponse>}
+    test_stub = stub_request(:get,'https://localhost/vsservice').to_return(:body=>valueset_xml)
     assert_raises HealthDataStandards::Util::MalformedVSQueryError do
+      api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
       api.get_valueset("oid", include_draft: true)
     end
+    assert_not_requested test_stub
   end
   
   def test_api_v2_with_include_draft_specified_profile

--- a/test/unit/util/vs_api_test.rb
+++ b/test/unit/util/vs_api_test.rb
@@ -72,8 +72,8 @@ class VSApiTest < Minitest::Test
   def test_api_v2_with_include_draft_no_profile
     valueset_xml = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23" version="Draft"></ValueSet></RetrieveValueSetResponse>}
     test_stub = stub_request(:get,'https://localhost/vsservice').to_return(:body=>valueset_xml)
+    api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
     assert_raises HealthDataStandards::Util::MalformedVSQueryError do
-      api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
       api.get_valueset("oid", include_draft: true)
     end
     assert_not_requested test_stub

--- a/test/unit/util/vs_api_test.rb
+++ b/test/unit/util/vs_api_test.rb
@@ -84,10 +84,8 @@ class VSApiTest < Minitest::Test
     valueset_xml = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23"></ValueSet></RetrieveValueSetResponse>}
     stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket"}).to_return(:body=>valueset_xml)
     api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
-    api.get_valueset("oid") do |oid, vs|
-      assert_equal "oid", oid
-      assert_equal valueset_xml, vs
-    end
+    vs = api.get_valueset("oid")
+    assert_equal valueset_xml, vs
   end
 
   def test_404_response

--- a/test/unit/util/vs_api_test.rb
+++ b/test/unit/util/vs_api_test.rb
@@ -69,6 +69,14 @@ class VSApiTest < Minitest::Test
     end
   end
   
+  def test_api_v2_with_include_draft_no_profile
+    valueset_xml = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23" version="Draft"></ValueSet></RetrieveValueSetResponse>}
+    api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
+    assert_raises HealthDataStandards::Util::MalformedVSQueryError do
+      api.get_valueset("oid", include_draft: true)
+    end
+  end
+  
   def test_api_v2_with_include_draft_specified_profile
     valueset_xml = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23" version="Draft"></ValueSet></RetrieveValueSetResponse>}
     stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket", :includeDraft=>"yes", :profile=>"Test Profile"}).to_return(:body=>valueset_xml)

--- a/test/unit/util/vs_api_test.rb
+++ b/test/unit/util/vs_api_test.rb
@@ -70,7 +70,6 @@ class VSApiTest < Minitest::Test
   end
   
   def test_api_v2_with_include_draft_no_profile
-    valueset_xml = %{<?xml version="1.0" encoding="UTF-8"?><RetrieveValueSetResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" cacheExpirationHint="2012-09-20T00:00:00-04:00" xmlns:nlm="urn:ihe:iti:svs:2008" xmlns="urn:ihe:iti:svs:2008"><ValueSet id="2.16.840.1.113883.11.20.9.23" version="Draft"></ValueSet></RetrieveValueSetResponse>}
     api = HealthDataStandards::Util::VSApiV2.new("https://localhost/token", "https://localhost/vsservice", "myusername", "mypassword")
     assert_raises HealthDataStandards::Util::MalformedVSQueryError do
       api.get_valueset("oid", include_draft: true)

--- a/test/unit/util/vs_api_test.rb
+++ b/test/unit/util/vs_api_test.rb
@@ -31,15 +31,15 @@ class VSApiTest < Minitest::Test
       unless valueset_xml_version[valueset_xml[0]] == ""
         stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket", :effectiveDate=>valueset_xml_version[valueset_xml[0]]}).to_return(:body=>valueset_xml_by_date[valueset_xml[0]])
         assert_equal valueset_xml_by_date[valueset_xml[0]], api.get_valueset("oid", valueset_xml_version[valueset_xml[0]])
-        vs_call_1 = api.get_valueset("oid", valueset_xml_version[valueset_xml[0]])
-        assert_equal valueset_xml_by_date[valueset_xml[0]], vs_call_1
+        vs = api.get_valueset("oid", valueset_xml_version[valueset_xml[0]])
+        assert_equal valueset_xml_by_date[valueset_xml[0]], vs
       end
 
       if valueset_xml_version[valueset_xml[0]] == ""
         stub_request(:get,'https://localhost/vsservice').with(:query =>{:id=>"oid", :ticket=>"ticket"}).to_return(:body=>valueset_xml_by_date[valueset_xml[0]])
         assert_equal valueset_xml_by_date[valueset_xml[0]], api.get_valueset("oid")
-        vs_call_2 = api.get_valueset("oid")
-        assert_equal valueset_xml_by_date[valueset_xml[0]], vs_call_2
+        vs = api.get_valueset("oid")
+        assert_equal valueset_xml_by_date[valueset_xml[0]], vs
       end
     end
 	end


### PR DESCRIPTION
Intent of PR is to bring the HDS vsac API into conformity with the vsac web api.

JIRA: https://jira.mitre.org/browse/BONNIE-1072
Tests: Automated


- [X] This pull request describes *why* these changes were made.
- [X] Tests are included and test edge cases
- [X] Link to JIRA test(s), if used: NA
- [X] JIRA test(s) have been added to sprint, if used NA
- [X] JIRA ticket for this PR: 
- [X] JIRA ticket links to this PR.
- [x] Automated regression test(s) pass (if applicable): 

Reviewer 1: @hossenlopp
- [x] The code is maintainable
- [x] The code reuses code or resources within the project ecosystem where applicable
- [x] The code achieves its purpose
- [x] The tests appropriately test edge cases
- [x] The tests pass: ONLY PASS LOCALLY. Travis errors are possibly a code issue from outside this PR. 

Reviewer 2: @c-monkey
- [x] The code is maintainable
- [x] The code reuses code or resources within the project ecosystem where applicable
- [x] The code achieves its purpose
- [x] The tests appropriately test edge cases
- [x] The tests pass
