### PR TITLE
Add support for multiple versions of the same bundle when one is deprecated

### DIFF
--- a/lib/health-data-standards/import/bundle/importer.rb
+++ b/lib/health-data-standards/import/bundle/importer.rb
@@ -31,7 +31,7 @@ module HealthDataStandards
 
             bundle = unpack_bundle(zip_file)
 
-            bundle_versions = Hash[* HealthDataStandards::CQM::Bundle.where({}).collect{|b| [b._id, b.version]}.flatten]
+            bundle_versions = Hash[* HealthDataStandards::CQM::Bundle.where({:deprecated.ne => true}).collect{|b| [b._id, b.version]}.flatten]
             if bundle_versions.invert[bundle.version] && !(options[:delete_existing])
               raise "A bundle with version #{bundle.version} already exists in the database. "
             end


### PR DESCRIPTION
Currently if a user tries to add a bundle that has the same version as an existing bundle then the importer will throw an error. In Cypress we have implemented a concept of deprecation which means that a bundle has been mostly deleted and only has the minimal things required for existing tests to be re-run. In order to allow for Cypress users to import a newer version of a bundle we would need to relax this requirement to only check if the conflicting version of the bundle is in a non-deprecated bundle.