### PR TITLE
Dump whole database as a whole because collections collection is empt…

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,9 +42,7 @@ class Minitest::Test
 
   # Delete all collections from the database.
   def dump_database
-    Mongoid.session(:default).collections.each do |collection|
-      collection.drop unless collection.name.include?('system.')
-    end
+    Mongoid.default_session.drop()
   end
 
 end


### PR DESCRIPTION
Dump whole database as a whole because collections collection is empty due to a mongoid update