### PR TITLE
Updated health-data-standards for 4.0.3 release.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    health-data-standards (4.0.2)
+    health-data-standards (4.0.3)
       activesupport (~> 4.2.0)
       builder (~> 3.1)
       erubis (~> 2.7.0)
@@ -147,4 +147,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/health-data-standards.gemspec
+++ b/health-data-standards.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '4.0.2'
+  s.version = '4.0.3'
 
   s.add_dependency 'rest-client', '~>1.8.0'
   s.add_dependency 'erubis', '~> 2.7.0'


### PR DESCRIPTION
Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links back to this PR N/A
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.) N/A
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass N/A
- [x] Code coverage has not gone down and all code touched or added is covered.
     * In rare situations, this may not be possible or applicable to a PR. In those situations: N/A
         1. Note why this could not be done or is not applicable here: N/A
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: N/A
 
**Cypress Reviewer:**
 
Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
 
**Bonnie Reviewer:**
 
Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
