### PR TITLE
adding participation data type

### DIFF
--- a/lib/health-data-standards.rb
+++ b/lib/health-data-standards.rb
@@ -84,6 +84,7 @@ require_relative 'health-data-standards/models/care_goal'
 require_relative 'health-data-standards/models/encounter_principal_diagnosis'
 require_relative 'health-data-standards/models/assessment'
 require_relative 'health-data-standards/models/adverse_event'
+require_relative 'health-data-standards/models/participation'
 
 require_relative 'health-data-standards/models/qrda/id'
 require_relative 'health-data-standards/models/qrda/device'

--- a/lib/health-data-standards/models/participation.rb
+++ b/lib/health-data-standards/models/participation.rb
@@ -1,0 +1,2 @@
+class Participation < Entry
+end

--- a/lib/health-data-standards/models/record.rb
+++ b/lib/health-data-standards/models/record.rb
@@ -53,10 +53,11 @@ class Record
   embeds_many :advance_directives, class_name: "Entry"
   embeds_many :insurance_providers
   embeds_many :functional_statuses
+  embeds_many :participation
 
   Sections = [:allergies, :care_goals, :conditions, :encounters, :immunizations, :medical_equipment,
    :medications, :procedures, :results, :communications, :family_history, :social_history, :vital_signs, :support, :advance_directives,
-   :insurance_providers, :functional_statuses, :care_experiences, :assessments, :adverse_events]
+   :insurance_providers, :functional_statuses, :care_experiences, :assessments, :adverse_events, :participation]
 
   embeds_many :provider_performances
   embeds_many :addresses, as: :locatable

--- a/lib/health-data-standards/models/record.rb
+++ b/lib/health-data-standards/models/record.rb
@@ -53,11 +53,11 @@ class Record
   embeds_many :advance_directives, class_name: "Entry"
   embeds_many :insurance_providers
   embeds_many :functional_statuses
-  embeds_many :participation
+  embeds_many :participations
 
   Sections = [:allergies, :care_goals, :conditions, :encounters, :immunizations, :medical_equipment,
    :medications, :procedures, :results, :communications, :family_history, :social_history, :vital_signs, :support, :advance_directives,
-   :insurance_providers, :functional_statuses, :care_experiences, :assessments, :adverse_events, :participation]
+   :insurance_providers, :functional_statuses, :care_experiences, :assessments, :adverse_events, :participations]
 
   embeds_many :provider_performances
   embeds_many :addresses, as: :locatable

--- a/lib/health-data-standards/util/hqmfr2cql_template_oid_map.json
+++ b/lib/health-data-standards/util/hqmfr2cql_template_oid_map.json
@@ -386,5 +386,9 @@
   "2.16.840.1.113883.10.20.28.4.119": {
     "definition":"allergy_intolerance",
     "status":"",
+    "negation":false},
+  "2.16.840.1.113883.10.20.28.4.130": {
+    "definition":"participation",
+    "status":"",
     "negation":false}
 }

--- a/lib/hqmf-model/data_criteria.json
+++ b/lib/hqmf-model/data_criteria.json
@@ -1045,11 +1045,11 @@
       "not_supported":false},
     "participation":{
         "title":"participation",
-        "category":"participation",
+        "category":"participations",
         "definition":"participation",
         "status":"",
         "sub_category":"",
         "hard_status":false,
-        "patient_api_function":"participation",
+        "patient_api_function":"participations",
         "not_supported":false}
 }

--- a/lib/hqmf-model/data_criteria.json
+++ b/lib/hqmf-model/data_criteria.json
@@ -1042,5 +1042,14 @@
       "sub_category":"",
       "hard_status":false,
       "patient_api_function":"allergies",
-      "not_supported":false}
+      "not_supported":false},
+    "participation":{
+        "title":"participation",
+        "category":"participation",
+        "definition":"participation",
+        "status":"",
+        "sub_category":"",
+        "hard_status":false,
+        "patient_api_function":"participation",
+        "not_supported":false}
 }

--- a/lib/hqmf-parser/2.0/value_set_helper.rb
+++ b/lib/hqmf-parser/2.0/value_set_helper.rb
@@ -92,8 +92,8 @@ module HQMF2
       '2.16.840.1.113883.10.20.28.3.117' => { valueset_path: './*/cda:code', result_path: './*/cda:value' },
       '2.16.840.1.113883.10.20.28.3.118' => { valueset_path: './*/cda:code', result_path: nil },
       '2.16.840.1.113883.10.20.28.3.119' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='MANU']/cda:playingEntity[@classCode='MMAT']/cda:code", result_path: nil },
-      '2.16.840.1.113883.10.20.28.3.120' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='MANU']/cda:playingEntity[@classCode='MMAT']/cda:code", result_path: nil }
-
+      '2.16.840.1.113883.10.20.28.3.120' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='MANU']/cda:playingEntity[@classCode='MMAT']/cda:code", result_path: nil },
+      '2.16.840.1.113883.10.20.28.3.130' => { valueset_path: './*/cda:value', result_path: nil }
     }
     # rubocop:enable Metrics/LineLength
 

--- a/lib/hqmf-parser/cql/value_set_helper.rb
+++ b/lib/hqmf-parser/cql/value_set_helper.rb
@@ -92,7 +92,8 @@ module HQMF2CQL
       '2.16.840.1.113883.10.20.28.4.117' => { valueset_path: './*/cda:code', result_path: './*/cda:value' },
       '2.16.840.1.113883.10.20.28.4.118' => { valueset_path: './*/cda:code', result_path: nil },
       '2.16.840.1.113883.10.20.28.4.119' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='MANU']/cda:playingEntity[@classCode='MMAT']/cda:code", result_path: nil },
-      '2.16.840.1.113883.10.20.28.4.120' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='MANU']/cda:playingEntity[@classCode='MMAT']/cda:code", result_path: nil }
+      '2.16.840.1.113883.10.20.28.4.120' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='MANU']/cda:playingEntity[@classCode='MMAT']/cda:code", result_path: nil },
+      '2.16.840.1.113883.10.20.28.4.130' => { valueset_path: './*/cda:value', result_path: nil }
     }
     # rubocop:enable Metrics/LineLength
 


### PR DESCRIPTION
Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [X] This pull request describes why these changes were made.
- [X] This PR is into the correct branch.
- [X] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1377
- [x] Internal ticket links back to this PR
- [X] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [X] Tests are included and test edge cases
- [X] Tests have been run locally and pass
- [X] Code coverage has not gone down and all code touched or added is covered.

Branch | Coverage
-- | --
bonnie-v2.1 | 1709 / 6975 / 7699 LOC (90.6%) covered. <br> 2692 / 7797 LOC (34.53%) covered.
bonnie_1025_participation_data_type | 6978 / 7702 LOC (90.6%) covered. <br> 2695 / 7800 LOC (34.55%) covered.

 
**Cypress Reviewer:**
 
Name: @dczulada 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
 
**Bonnie Reviewers:**
 
Name: @losborne 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

Name: @holmesie
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
