### PR TITLE
Updated health_data_standards for 4.0.5 release.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    health-data-standards (4.0.4)
+    health-data-standards (4.0.5)
       activesupport (~> 4.2.0)
       builder (~> 3.1)
       erubis (~> 2.7.0)

--- a/health-data-standards.gemspec
+++ b/health-data-standards.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '4.0.4'
+  s.version = '4.0.5'
 
   s.add_dependency 'rest-client', '~>1.8.0'
   s.add_dependency 'erubis', '~> 2.7.0'


### PR DESCRIPTION
Version bump for patch release.

Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] ~~Tests have been run locally and pass~~ n/a
 
**Bonnie Reviewer:**
 
Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] You have tried to break the code
