### PR TITLE
Align classcodes with hqmf spec for substance recommended

### DIFF
--- a/lib/hqmf-parser/cql/value_set_helper.rb
+++ b/lib/hqmf-parser/cql/value_set_helper.rb
@@ -75,7 +75,7 @@ module HQMF2CQL
       '2.16.840.1.113883.10.20.28.4.75' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='ADMM']/cda:playingMaterial[@classCode='MAT' and @determinerCode='KIND']/cda:code", result_path: nil },
       '2.16.840.1.113883.10.20.28.4.76' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='ADMM']/cda:playingMaterial[@classCode='MAT' and @determinerCode='KIND']/cda:code", result_path: nil },
       '2.16.840.1.113883.10.20.28.4.77' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='ADMM']/cda:playingMaterial[@classCode='MAT' and @determinerCode='KIND']/cda:code", result_path: nil },
-      '2.16.840.1.113883.10.20.28.4.78' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='MANU']/cda:playingMaterial[@classCode='MMAT' and @determinerCode='KIND']/cda:code", result_path: nil },
+      '2.16.840.1.113883.10.20.28.4.78' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='ADMM']/cda:playingMaterial[@classCode='MAT' and @determinerCode='KIND']/cda:code", result_path: nil },
       '2.16.840.1.113883.10.20.28.4.79' => { valueset_path: './*/cda:value', result_path: nil },
       '2.16.840.1.113883.10.20.28.4.80' => { valueset_path: './*/cda:value', result_path: nil },
       '2.16.840.1.113883.10.20.28.4.81' => { valueset_path: './*/cda:value', result_path: nil },


### PR DESCRIPTION
Align substance_recommended definition with cql_hqmf_ ig. 
![image](https://user-images.githubusercontent.com/3967953/41037383-3316a692-6961-11e8-897c-7e397635ca09.png)

Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1534
- [x] Internal ticket links back to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases NA
- [x] Tests have been run locally and pass NA
- [x] Code coverage has not gone down and all code touched or added is covered.
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here:
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: https://jira.mitre.org/browse/BONNIE-1543
 
**Cypress Reviewer:**
 
Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
 
**Bonnie Reviewer:**
 
Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
