### PR TITLE
Updated health-data-standards for 4.0.6 release.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    health-data-standards (4.0.5)
+    health-data-standards (4.0.6)
       activesupport (~> 4.2.0)
       builder (~> 3.1)
       erubis (~> 2.7.0)
@@ -147,4 +147,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/health-data-standards.gemspec
+++ b/health-data-standards.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '4.0.5'
+  s.version = '4.0.6'
 
   s.add_dependency 'rest-client', '~>1.8.0'
   s.add_dependency 'erubis', '~> 2.7.0'


### PR DESCRIPTION
Gemfile version update.

Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links back to this PR N/A
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered. N/A

**Bonnie Reviewer:**
 
Name: @jbradl11 
- [x] Gemfile.lock sanity check
