### PR TITLE
Update nokogiri version for security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,9 +15,10 @@ PATH
       highline (~> 1.7.0)
       log4r (~> 1.1.10)
       memoist (~> 0.9.1)
+      mongo (~> 2.4.3)
       mongoid (~> 5.0.0)
       mongoid-tree (~> 2.0.0)
-      nokogiri (~> 1.8.2)
+      nokogiri (~> 1.8.3)
       protected_attributes (~> 1.0.5)
       rest-client (~> 1.8.0)
       rubyzip (~> 1.2.1)
@@ -39,7 +40,7 @@ GEM
     addressable (2.4.0)
     ansi (1.5.0)
     awesome_print (1.7.0)
-    bson (4.2.2)
+    bson (4.3.0)
     builder (3.2.2)
     bundler-audit (0.5.0)
       bundler (~> 1.2)
@@ -50,13 +51,13 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     docile (1.1.5)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     factory_girl (4.1.0)
       activesupport (>= 3.0.0)
     hashdiff (0.3.0)
-    highline (1.7.8)
+    highline (1.7.10)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -84,7 +85,7 @@ GEM
     mongoid-tree (2.0.1)
       mongoid (>= 4.0, < 6.0)
     netrc (0.11.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     origin (2.3.1)
     parallel (1.9.0)
@@ -118,8 +119,8 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.4)
-    uuid (2.3.8)
+    unf_ext (0.0.7.5)
+    uuid (2.3.9)
       macaddr (~> 1.0)
     webmock (2.1.0)
       addressable (>= 2.3.6)
@@ -147,4 +148,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/health-data-standards.gemspec
+++ b/health-data-standards.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'protected_attributes', '~> 1.0.5'
   s.add_dependency 'uuid', '~> 2.3.7'
   s.add_dependency 'builder', '~> 3.1'
-  s.add_dependency 'nokogiri', '~> 1.8.2'
+  s.add_dependency 'nokogiri', '~> 1.8.3'
+  s.add_dependency 'mongo', '~> 2.4.3'
   s.add_dependency 'highline', "~> 1.7.0"
 
   s.add_dependency 'rubyzip', '~> 1.2.1'


### PR DESCRIPTION
Update nokogiri due to security vulnerability
Lock down mongo so it doesn't update too much

Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1615
- [x] Internal ticket links back to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.

 
**Bonnie Reviewer:**
 
Name: @hossenlopp 
- [x] Gemfile update sanity check
