### PR TITLE
adding assessment order

### DIFF
--- a/lib/health-data-standards/util/hqmfr2cql_template_oid_map.json
+++ b/lib/health-data-standards/util/hqmfr2cql_template_oid_map.json
@@ -371,6 +371,10 @@
       "definition":"transfer_to",
       "status":"",
       "negation":false},
+  "2.16.840.1.113883.10.20.28.4.131":{
+      "definition":"assessment",
+      "status":"ordered",
+      "negation":false},
   "2.16.840.1.113883.10.20.28.4.117":{
     "definition":"assessment",
     "status":"performed",

--- a/lib/hqmf-model/data_criteria.json
+++ b/lib/hqmf-model/data_criteria.json
@@ -1007,6 +1007,15 @@
       "hard_status":false,
       "patient_api_function":"encounters",
       "not_supported":false},
+  "assessment_ordered":{
+      "title":"assessment order",
+      "category":"assessments",
+      "definition":"assessment",
+      "status":"ordered",
+      "sub_category":"",
+      "hard_status":false,
+      "patient_api_function":"assessments",
+      "not_supported":false},
   "assessment_performed":{
       "title":"assessment performed",
       "category":"assessments",

--- a/lib/hqmf-parser/cql/value_set_helper.rb
+++ b/lib/hqmf-parser/cql/value_set_helper.rb
@@ -93,7 +93,8 @@ module HQMF2CQL
       '2.16.840.1.113883.10.20.28.4.118' => { valueset_path: './*/cda:code', result_path: nil },
       '2.16.840.1.113883.10.20.28.4.119' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='MANU']/cda:playingEntity[@classCode='MMAT']/cda:code", result_path: nil },
       '2.16.840.1.113883.10.20.28.4.120' => { valueset_path: "./*/cda:participation[@typeCode='CSM']/cda:role[@classCode='MANU']/cda:playingEntity[@classCode='MMAT']/cda:code", result_path: nil },
-      '2.16.840.1.113883.10.20.28.4.130' => { valueset_path: './*/cda:value', result_path: nil }
+      '2.16.840.1.113883.10.20.28.4.130' => { valueset_path: './*/cda:value', result_path: nil },
+      '2.16.840.1.113883.10.20.28.4.131' => { valueset_path: './*/cda:code', result_path: nil }
     }
     # rubocop:enable Metrics/LineLength
 


### PR DESCRIPTION
adding assessment order. no new attributes required for the 'assessment' type.

Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1599
- [x] Internal ticket links back to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] ~Tests are included and test edge cases~
  - effective testing of this code requires examples of assessment, order which we do not yet have.
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
  - bonnie-v3.0: 90.49
  - this branch: 90.49
 
**Cypress Reviewer:**
 
Name: Dave Czulada
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
 
**Bonnie Reviewer:**
 
Name: @losborne
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
