### PR TITLE
Add setting attribute to medication

### DIFF
--- a/lib/health-data-standards/models/medication.rb
+++ b/lib/health-data-standards/models/medication.rb
@@ -5,6 +5,7 @@ class Medication < Entry
   # QDM 5.0 disambiguates dose to be dosage and suppy. 'dose' here represents the QDM 5.0 'dosage'.
   # Bonnie displays this as 'dosage'.
   field :dose, type: Hash
+  field :setting, type: Hash
   field :supply, type: Hash
   field :refills, type: Hash
   field :typeOfMedication, as: :type_of_medication, type: Hash

--- a/lib/hqmf-model/data_criteria.rb
+++ b/lib/hqmf-model/data_criteria.rb
@@ -77,6 +77,7 @@ module HQMF
               # TODO: (LDY 10/4/2016) RESULT_DATETIME is a new attribute in QDM 5.0. We do not yet have codes/template information for this.
               'RESULT_DATETIME' => {title:'Result Date/Time', coded_entry_method: :result_date_time, field_type: :timestamp},
               'ROUTE' => {title:'Route', coded_entry_method: :route, code: '263513008', code_system:'2.16.840.1.113883.6.96', template_id: '2.16.840.1.113883.3.560.1.1020.2', field_type: :value},
+              'SETTING' => {title:'Setting', coded_entry_method: :setting, field_type: :value},
               'SEVERITY' => {title:'Severity', coded_entry_method: :severity, code: 'SEV', code_system:'2.16.840.1.113883.5.4', template_id: '2.16.840.1.113883.10.20.22.4.8', field_type: :value},
               'SIGNED_DATETIME' =>  {title:'Signed Date/Time', coded_entry_method: :signed_date_time, field_type: :timestamp},
               'START_DATETIME' => {title:'Start Date/Time', coded_entry_method: :start_date, code: '398201009', code_system:'2.16.840.1.113883.6.96', template_id: '2.16.840.1.113883.3.560.1.1027.1', field_type: :timestamp},

--- a/test/unit/models/medication_test.rb
+++ b/test/unit/models/medication_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+ class ProcedureTest < Minitest::Test
+  # test content geared for QDM 5.4
+  # only testing QDM 5.4 diffs for now
+   def setup
+    @medication = Medication.new
+  end
+   # setting attribute added to medication order in QDM 5.4
+  def test_anatomical_approach_not_present
+    assert @medication.respond_to?(:setting)
+  end
+end

--- a/test/unit/models/medication_test.rb
+++ b/test/unit/models/medication_test.rb
@@ -6,7 +6,7 @@ require 'test_helper'
     @medication = Medication.new
   end
    # setting attribute added to medication order in QDM 5.4
-  def test_anatomical_approach_not_present
+  def test_setting_not_present
     assert @medication.respond_to?(:setting)
   end
 end

--- a/test/unit/models/medication_test.rb
+++ b/test/unit/models/medication_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
- class ProcedureTest < Minitest::Test
+ class MedicationTest < Minitest::Test
   # test content geared for QDM 5.4
   # only testing QDM 5.4 diffs for now
-   def setup
+  def setup
     @medication = Medication.new
   end
    # setting attribute added to medication order in QDM 5.4


### PR DESCRIPTION
Setting code attribute was added to MedicationOrder in QDM5.4
Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1656
- [x] Internal ticket links back to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases 
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here:
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here:
 
**Cypress Reviewer:**
 
Name: Dave Czulada
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
 
**Bonnie Reviewer:**
 
Name: @edeyoung
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
  - more applicable when we have actual examples to use this against.
