### PR TITLE
added days supplied to medication

### DIFF
--- a/lib/health-data-standards/models/medication.rb
+++ b/lib/health-data-standards/models/medication.rb
@@ -29,6 +29,8 @@ class Medication < Entry
   field :prescriberIdentifier, as: :prescriber_identifier, type: Hash
   field :patientInstructions, as: :patient_instructions, type: String
   field :doseIndicator, as: :dose_indicator, type: String
+  field :daysSupplied, as: :days_supplied, type: Hash
+
 
   # In QDM 5.4: method not present on 'medication'. deprecated for 'substance' (particularly, 'Substance, Recommended')
   field :method ,   type: Hash 

--- a/lib/health-data-standards/models/medication.rb
+++ b/lib/health-data-standards/models/medication.rb
@@ -31,7 +31,6 @@ class Medication < Entry
   field :doseIndicator, as: :dose_indicator, type: String
   field :daysSupplied, as: :days_supplied, type: Hash
 
-
   # In QDM 5.4: method not present on 'medication'. deprecated for 'substance' (particularly, 'Substance, Recommended')
   field :method ,   type: Hash 
   field :active_datetime ,  type: Integer

--- a/lib/hqmf-model/data_criteria.rb
+++ b/lib/hqmf-model/data_criteria.rb
@@ -40,6 +40,8 @@ module HQMF
               'COMPONENT' => {title: 'Component', coded_entry_method: :components, field_type: :value},
               'CUMULATIVE_MEDICATION_DURATION' => {title:'Cumulative Medication Duration', coded_entry_method: :cumulative_medication_duration, code: '261773006', code_system:'2.16.840.1.113883.6.96', template_id: '2.16.840.1.113883.3.560.1.1001.3', field_type: :value},
               # MISSING Date - The date that the patient passed away. - Patient Characteristic Expired
+              # Could not find a code and code_system for this data criteria (days supplied) in HQMF QDM IG v3
+              'DAYS_SUPPLIED' => {title:'Days Supplied', coded_entry_method: :days_supplied, field_type: :value},
               'DIAGNOSIS' => {title:'Diagnosis', coded_entry_method: :diagnosis, field_type: :value},
               'DISCHARGE_DATETIME' => {title:'Discharge Date/Time', coded_entry_method: :discharge_time, code: '442864001', code_system:'2.16.840.1.113883.6.96', template_id: '2.16.840.1.113883.3.560.1.1025.1', field_type: :timestamp},
               # TODO: (LDY 10/5/2016) this changed from "discharge status" to "discharge disposition". likely there is a code and template id change necessary. these are not yet known.

--- a/test/unit/models/medication_test.rb
+++ b/test/unit/models/medication_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
- class MedicationTest < Minitest::Test
+
+class MedicationTest < Minitest::Test
   # test content geared for QDM 5.4
   # only testing QDM 5.4 diffs for now
   def setup
@@ -14,5 +15,8 @@ require 'test_helper'
   end
   def test_prescriber_identifier_present
     assert @medication.respond_to?(:prescriber_identifier)
+  end
+  def test_days_supplied_present
+    assert @medication.respond_to?(:days_supplied)
   end
 end


### PR DESCRIPTION
This PR adds a "Days Supplied" attribute to: Medication Order, Dispensed and Discharge. The field is a number indicating the number of days a supply of medication should last.

Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1690
- [x] Internal ticket links back to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here:
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here:
 
**Cypress Reviewer:**
 
Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
 
**Bonnie Reviewer:**
 
Name: @hossenlopp
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
