### PR TITLE
Update header versions

### DIFF
--- a/templates/cat1/r5/_patient_data.cat1.erb
+++ b/templates/cat1/r5/_patient_data.cat1.erb
@@ -3,9 +3,9 @@
           <!-- This is the templateId for Patient Data section -->
           <templateId root="2.16.840.1.113883.10.20.17.2.4"/>
           <!-- This is the templateId for Patient Data QDM section -->
-	        <templateId root="2.16.840.1.113883.10.20.24.2.1" extension="2016-08-01" />
+	        <templateId root="2.16.840.1.113883.10.20.24.2.1" extension="2017-08-01" />
           <% if cms_compatibility %>
-            <templateId root="2.16.840.1.113883.10.20.24.2.1.1" extension="2017-07-01"/>
+            <templateId root="2.16.840.1.113883.10.20.24.2.1.1" extension="2018-02-01"/>
           <% end %>
           <code code="55188-7" codeSystem="2.16.840.1.113883.6.1"/>
           <title>Patient Data</title>

--- a/templates/cat1/r5/show.cat1.erb
+++ b/templates/cat1/r5/show.cat1.erb
@@ -15,12 +15,12 @@
   <!-- US Realm Header Template Id -->
   <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
   <!-- QRDA templateId -->
-  <templateId root="2.16.840.1.113883.10.20.24.1.1" extension="2016-02-01"/>
+  <templateId root="2.16.840.1.113883.10.20.24.1.1" extension="2017-08-01"/>
   <!-- QDM-based QRDA templateId -->
-  <templateId root="2.16.840.1.113883.10.20.24.1.2" extension="2016-02-01"/>
+  <templateId root="2.16.840.1.113883.10.20.24.1.2" extension="2017-08-01"/>
   <% if cms_compatibility %>
   <!-- CMS QRDA templateId -->
-  <templateId root="2.16.840.1.113883.10.20.24.1.3" extension="2017-07-01" />
+  <templateId root="2.16.840.1.113883.10.20.24.1.3" extension="2018-02-01" />
   <% end %>
   <!-- This is the globally unique identifier for this QRDA document -->
   <id root="<%= UUID.generate %>"/>

--- a/templates/cat1/r5/show.cat1.erb
+++ b/templates/cat1/r5/show.cat1.erb
@@ -15,7 +15,7 @@
   <!-- US Realm Header Template Id -->
   <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
   <!-- QRDA templateId -->
-  <templateId root="2.16.840.1.113883.10.20.24.1.1" extension="2017-08-01"/>
+  <templateId root="2.16.840.1.113883.10.20.24.1.1" extension="2016-02-01"/>
   <!-- QDM-based QRDA templateId -->
   <templateId root="2.16.840.1.113883.10.20.24.1.2" extension="2017-08-01"/>
   <% if cms_compatibility %>


### PR DESCRIPTION
The QRDA header was still using old QRDA template ids.

Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
 
**Cypress Reviewer:**
 
Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
 
**Bonnie Reviewer:**
 
Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
