### PR TITLE
update rubyzip version for zipslip vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     ruby-progressbar (1.8.1)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     simplecov (0.11.2)
       docile (~> 1.1.0)


### PR DESCRIPTION
Update version because of https://github.com/snyk/zip-slip-vulnerability


Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1739
- [x] Internal ticket links back to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests have been run locally and pass
 
**Cypress Reviewer:**
 
Name:
~- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose~
~- [ ] The tests appropriately test the new code, including edge cases~
~- [ ] You have tried to break the code~
 
**Bonnie Reviewer:**
 
Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases NA
- [x] You have tried to break the code
