### PR TITLE
Add logic to scoop and filter to allow for DRC data elements

### DIFF
--- a/lib/health-data-standards/export/helper/scooped_view_helper.rb
+++ b/lib/health-data-standards/export/helper/scooped_view_helper.rb
@@ -137,7 +137,14 @@ module HealthDataStandards
               end
             end
 
-            codes ||= (value_set_map(patient["bundle_id"])[data_criteria.code_list_id] || [])
+            # if the data criteria uses a direct reference code, the code_list_id will be drc-****
+            # direct reference codes reference a single code and do not appear in the value_set_map
+            if data_criteria.code_list_id && data_criteria.code_list_id.match(/^drc-/)
+              codes = [{'set' => data_criteria.inline_code_list.keys[0], 'values' => data_criteria.inline_code_list.values[0]}]
+            else
+              codes ||= (value_set_map(patient["bundle_id"])[data_criteria.code_list_id] || [])
+            end
+
             if codes.empty?
               HealthDataStandards.logger.warn("No codes for #{data_criteria.code_list_id}")
             end

--- a/lib/health-data-standards/export/helper/scooped_view_helper.rb
+++ b/lib/health-data-standards/export/helper/scooped_view_helper.rb
@@ -137,7 +137,7 @@ module HealthDataStandards
               end
             end
 
-            # if the data criteria uses a direct reference code, the code_list_id will be drc-****
+            # If the data criteria uses a direct reference code, the code_list_id will be drc-****
             # direct reference codes reference a single code and do not appear in the value_set_map
             if data_criteria.code_list_id && data_criteria.code_list_id.match(/^drc-/)
               codes = [{'set' => data_criteria.inline_code_list.keys[0], 'values' => data_criteria.inline_code_list.values[0]}]

--- a/templates/cat1/r5/_2.16.840.1.113883.10.20.24.3.144.cat1.erb
+++ b/templates/cat1/r5/_2.16.840.1.113883.10.20.24.3.144.cat1.erb
@@ -14,8 +14,10 @@
       <low <%= value_or_null_flavor(entry.start_time) %>/>
       <high <%= value_or_null_flavor(entry.end_time) %>/>
     </effectiveTime>
+    <%== render(:partial => 'method', :locals => {:entry => entry, :method_oids=>field_oids["METHOD"]}) %>
     <%== render(:partial => 'result_value', :locals => {:values => [value], :result_oids=>result_oids} ) %>
     <%== render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
+    <%== render(:partial => 'fulfills', :locals => {:entry => entry}) %>
     <% if entry.components -%>
       <%== render(:partial => 'components', :locals => {:entry => entry} ) %>
     <% end %>

--- a/templates/cat1/r5/_2.16.840.1.113883.10.20.24.3.3.cat1.erb
+++ b/templates/cat1/r5/_2.16.840.1.113883.10.20.24.3.3.cat1.erb
@@ -1,5 +1,6 @@
 <entry>
   <act classCode="ACT" moodCode="EVN" <%== negation_indicator(entry) %>>
+    <!-- Communication from provider to patient -->
     <templateId root="2.16.840.1.113883.10.20.24.3.3" extension="2017-08-01"/>
     <id root="1.3.6.1.4.1.115" extension="<%= entry.id %>"/>  
     <%== code_display(entry, 'value_set_map' => filtered_vs_map, 'preferred_code_sets' => ['SNOMED-CT', 'LOINC']) %>

--- a/templates/cat1/r5/_2.16.840.1.113883.10.20.24.3.59.cat1.erb
+++ b/templates/cat1/r5/_2.16.840.1.113883.10.20.24.3.59.cat1.erb
@@ -16,6 +16,7 @@
       <high <%= value_or_null_flavor(entry.end_time) %>/>
     </effectiveTime>
     <%== render(:partial => 'result_value', :locals => {:values => [value], :result_oids=>result_oids}) %>
+    <%== render(:partial => 'method', :locals => {:entry => entry, :method_oids=>field_oids["METHOD"]}) %>
     <%== render(:partial => 'reason', :locals => {:entry => entry, :reason_oids=>field_oids["REASON"]}) %>
     <% if entry.components -%>
       <%== render(:partial => 'components', :locals => {:entry => entry} ) %>

--- a/templates/cat1/r5/_fulfills.cat1.erb
+++ b/templates/cat1/r5/_fulfills.cat1.erb
@@ -2,7 +2,7 @@
   -%>
   <% entry.references.each do |reference| 
     resolved_reference = reference.resolve_reference %>
-  <% if reference.type == "fulfills" %>
+  <% if reference.type == "fulfills" || reference.type == "Related To" %>
   <sdtc:inFulfillmentOf1 typeCode="FLFS">
     <sdtc:templateId root="2.16.840.1.113883.10.20.24.3.126" extension="2016-08-01"/>
       <sdtc:actReference classCode="ACT" moodCode="<%= resolved_reference.mood_code %>">

--- a/test/unit/export/cat_1_qrda_r5_test.rb
+++ b/test/unit/export/cat_1_qrda_r5_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+
 class Cat1TestQRDAR5 < Minitest::Test
   include HealthDataStandards::Export::Helper::Cat1ViewHelper
 

--- a/test/unit/export/cat_1_qrda_r5_test.rb
+++ b/test/unit/export/cat_1_qrda_r5_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-
 class Cat1TestQRDAR5 < Minitest::Test
   include HealthDataStandards::Export::Helper::Cat1ViewHelper
 
@@ -470,30 +469,69 @@ class Cat1TestQRDAR5 < Minitest::Test
     # • device applied missing “anatomical approach site” and “anatomical location”
     # (not present in Bonnie)
     def test_CMS108_serialization
-      # _test_assessment_performed_serialization
+      _test_assessment_performed_serialization
       _test_device_applied_serialization
       _test_device_order_serialization
       _test_medication_administered_serialization
       _test_medication_order_serialization
     end
 
-    # TODO: CMS108 seems to get parsed in a way where the assessment performed has
-    # an unusable code_list_id (non-oid). Skipping this test until that's resolved.
-    # see https://jira.mitre.org/browse/BONNIE-1649
-    # def _test_assessment_performed_serialization
-    #   assessment_performed_xpath = get_entry_xpath("2.16.840.1.113883.10.20.24.3.144")
-    #   assessment_performed_node = @doc_108v7.xpath(assessment_performed_xpath)
-    #   # code, LOINC: 72136-5
-    #   # authorDatetime, 08/01/2012 8:00 AM
-    #
-    #   # reason, Reason: Comfort Measures
-    #   # method, Method: General Surgery
-    #   # result, 06/14/2012 8:00 AM
-    #   # components, Component: General or Neuraxial Anesthesia, Hip Replacement Surgery
-    #   # Component: Direct Thrombin Inhibitor, 34 mg
-    #   # Component: Glycoprotein IIb/IIIa Inhibitors, 05/16/2012 8:00 AM
-    #   # relatedTo, Related To: Device, Applied: Venous foot pumps (VFP) 08/01/2012
-    # end
+    def _test_assessment_performed_serialization
+      assessment_performed_xpath = get_entry_xpath("2.16.840.1.113883.10.20.24.3.144")
+      assessment_performed_node = @doc_108v7.xpath(assessment_performed_xpath)
+      assert_equal 1, assessment_performed_node.count
+      code_node = assessment_performed_node.xpath("./xmlns:observation/xmlns:code")
+      assert_equal 1, code_node.count
+      assert_equal "72136-5", code_node.xpath("./@code").inner_text
+
+      # relevant period
+      relevant_period_node = assessment_performed_node.xpath("./xmlns:observation/xmlns:effectiveTime")
+      start = relevant_period_node.xpath("./xmlns:low/@value")
+      stop = relevant_period_node.xpath("./xmlns:high/@value")
+      stop_undef = relevant_period_node.xpath("./xmlns:high/@nullFlavor")
+      assert_equal "20120801080000", start.inner_text
+      assert_equal 0, stop.count
+      assert_equal "UNK", stop_undef.inner_text
+      # reason
+      reason_node = assessment_performed_node.xpath("./xmlns:observation/xmlns:entryRelationship/xmlns:observation/xmlns:templateId[@root='2.16.840.1.113883.10.20.24.3.88']/parent::xmlns:observation/xmlns:value")
+      assert_equal 1, reason_node.count
+      assert_equal "133918004", reason_node.xpath("./@code").inner_text
+      # method
+      method_node = assessment_performed_node.xpath("./xmlns:observation/xmlns:methodCode")
+      assert_equal 1, method_node.count
+      assert_equal "008Q0ZZ", method_node.xpath("./@code").inner_text
+
+      # result
+      result_value = assessment_performed_node.xpath("./xmlns:observation/xmlns:value")
+      assert_equal 1, result_value.count
+      assert_equal "1339660800000", result_value.xpath("./@value").inner_text
+
+      # components
+      component_nodes = assessment_performed_node.xpath("./xmlns:observation/xmlns:entryRelationship/xmlns:observation/xmlns:templateId[@root='2.16.840.1.113883.10.20.24.3.149']/../..")
+      assert_equal 3, component_nodes.count
+
+      component_node1 = component_nodes.xpath("./xmlns:observation/xmlns:code[@code='112943005']/../..")
+      component_node2 = component_nodes.xpath("./xmlns:observation/xmlns:code[@code='1037045']/../..")
+      component_node3 = component_nodes.xpath("./xmlns:observation/xmlns:code[@code='1736470']/../..")
+      assert_equal 1, component_node1.count
+      assert_equal 1, component_node2.count
+      assert_equal 1, component_node3.count
+      # component 1
+      assert_equal "0SP909Z", component_node1.xpath("./xmlns:observation/xmlns:value/@code").inner_text
+      assert_equal "2.16.840.1.113883.6.4", component_node1.xpath("./xmlns:observation/xmlns:value/@codeSystem").inner_text
+      # component 2
+      assert_equal "34", component_node2.xpath("./xmlns:observation/xmlns:value/@value").inner_text
+      assert_equal "mg", component_node2.xpath("./xmlns:observation/xmlns:value/@unit").inner_text
+      # component 3
+      assert_equal "443421006080000", component_node3.xpath("./xmlns:observation/xmlns:value/@value").inner_text
+
+      # relatedTo
+      related_to_node = assessment_performed_node.xpath("./xmlns:observation/sdtc:inFulfillmentOf1")
+      assert_equal 1, related_to_node.count
+      related_to_id = related_to_node.xpath("sdtc:actReference/sdtc:id/@extension")[0].value
+      assert_equal "5b6c247cb848464add0870ee", related_to_id
+
+    end
 
     def _test_device_applied_serialization
       device_applied_xpath = get_entry_xpath("2.16.840.1.113883.10.20.24.3.7")
@@ -790,7 +828,7 @@ class Cat1TestQRDAR5 < Minitest::Test
     def test_CMS144_serialization
       _test_allergy_intolerance_serialization
       _test_diagnostic_study_performed_serialization
-      # _test_physical_exam_performed_serialization
+      _test_physical_exam_performed_serialization
     end
 
     def _test_allergy_intolerance_serialization
@@ -905,23 +943,56 @@ class Cat1TestQRDAR5 < Minitest::Test
 
     end
 
-    # TODO: CMS144 seems to get parsed in a way where the physical exam performed has
-    # an unusable code_list_id (non-oid). Skipping this test until that's resolved.
-    # see https://jira.mitre.org/browse/BONNIE-1649
-    # def _test_physical_exam_performed_serialization
-    #   physical_exam_performed_xpath = get_entry_xpath("2.16.840.1.113883.10.20.24.3.59")
-    #   physical_exam_performed_node = @doc_144v7.xpath(physical_exam_performed_xpath)
-    #
-    #   # code, LOINC: 8867-4
-    #   # relevantPeriod, start and stop, 08/01/2012 8:00 AM and 08/01/2012 11:00 AM
-    #   # reason, Reason: Bradycardia
-    #   # method, Method: Cardiac Pacer in Situ
-    #   # result, 29 mg
-    #   # anatomicalLocationSite, ???
-    #   # negationRationale, ???
-    #   # components, Component: Intolerance to Beta Blocker Therapy, Nursing Facility Visit
-    #   # Component: Medical Reason, 5 mg
-    #   # Component: Ejection Fraction, 08/01/2012 10:00 AM
-    # end
+    def _test_physical_exam_performed_serialization
+      physical_exam_performed_xpath = get_entry_xpath("2.16.840.1.113883.10.20.24.3.59")
+      physical_exam_performed_node = @doc_144v7.xpath(physical_exam_performed_xpath)
+
+      assert_equal 1, physical_exam_performed_node.count
+      code_node = physical_exam_performed_node.xpath("./xmlns:observation/xmlns:code")
+      assert_equal 1, code_node.count
+      assert_equal "8867-4", code_node.xpath("./@code").inner_text
+
+      # relevant period
+      relevant_period_node = physical_exam_performed_node.xpath("./xmlns:observation/xmlns:effectiveTime")
+      start = relevant_period_node.xpath("./xmlns:low/@value")
+      stop = relevant_period_node.xpath("./xmlns:high/@value")
+      assert_equal "20120801080000", start.inner_text
+      assert_equal 1, stop.count
+      assert_equal "20120801081500", stop.inner_text
+
+      # reason
+      reason_node = physical_exam_performed_node.xpath("./xmlns:observation/xmlns:entryRelationship/xmlns:observation/xmlns:templateId[@root='2.16.840.1.113883.10.20.24.3.88']/parent::xmlns:observation/xmlns:value")
+      assert_equal 1, reason_node.count
+      assert_equal "251162005", reason_node.xpath("./@code").inner_text
+
+      # method
+      method_node = physical_exam_performed_node.xpath("./xmlns:observation/xmlns:methodCode")
+      assert_equal 1, method_node.count
+      assert_equal "441509002", method_node.xpath("./@code").inner_text
+
+      # result
+      result_value = physical_exam_performed_node.xpath("./xmlns:observation/xmlns:value")
+      assert_equal 1, result_value.count
+      assert_equal "29", result_value.xpath("./@value").inner_text
+
+      # components
+      component_nodes = physical_exam_performed_node.xpath("./xmlns:observation/xmlns:entryRelationship/xmlns:observation/xmlns:templateId[@root='2.16.840.1.113883.10.20.24.3.149']/../..")
+      assert_equal 3, component_nodes.count
+
+      component_node1 = component_nodes.xpath("./xmlns:observation/xmlns:code[@code='292419005']/../..")
+      component_node2 = component_nodes.xpath("./xmlns:observation/xmlns:code[@code='183932001']/../..")
+      component_node3 = component_nodes.xpath("./xmlns:observation/xmlns:code[@code='10230-1']/../..")
+      assert_equal 1, component_node1.count
+      assert_equal 1, component_node2.count
+      assert_equal 1, component_node3.count
+      # component 1
+      assert_equal "18170008", component_node1.xpath("./xmlns:observation/xmlns:value/@code").inner_text
+      assert_equal "2.16.840.1.113883.6.96", component_node1.xpath("./xmlns:observation/xmlns:value/@codeSystem").inner_text
+      # component 2
+      assert_equal "5", component_node2.xpath("./xmlns:observation/xmlns:value/@value").inner_text
+      assert_equal "mg", component_node2.xpath("./xmlns:observation/xmlns:value/@unit").inner_text
+      # component 3
+      assert_equal "20120801100000", component_node3.xpath("./xmlns:observation/xmlns:value/@value").inner_text
+    end
   end
 end


### PR DESCRIPTION
Add logic to scoop and filter to allow for DRC data elements

Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1796
- [x] Internal ticket links back to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered. 90.59% -> 90.59%
 
**Cypress Reviewer:**
 
Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
 
**Bonnie Reviewer:**
 
Name: @zlister 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
