### PR TITLE
Update rest-client from 1.8.0 to 2.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ PATH
       mongoid-tree (~> 2.0.0)
       nokogiri (~> 1.8.3)
       protected_attributes (~> 1.0.5)
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0.1)
       rubyzip (~> 1.2.1)
       uuid (~> 2.3.7)
       zip-zip (~> 0.3)
@@ -69,7 +69,9 @@ GEM
     macaddr (1.7.1)
       systemu (~> 2.6.2)
     memoist (0.9.3)
-    mime-types (2.99.3)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mini_portile2 (2.3.0)
     minitest (5.9.0)
     minitest-reporters (1.1.9)
@@ -94,10 +96,10 @@ GEM
     protected_attributes (1.0.9)
       activemodel (>= 4.0.1, < 5.0)
     rake (11.2.2)
-    rest-client (1.8.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     ruby-progressbar (1.8.1)
     rubyzip (1.2.2)
     safe_yaml (1.0.4)
@@ -150,4 +152,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/health-data-standards.gemspec
+++ b/health-data-standards.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.version = '4.3.2'
 
-  s.add_dependency 'rest-client', '~>1.8.0'
+  s.add_dependency 'rest-client', '~>2.0.1'
   s.add_dependency 'erubis', '~> 2.7.0'
   s.add_dependency 'mongoid', '~> 5.0.0'
   s.add_dependency 'mongoid-tree', '~> 2.0.0'


### PR DESCRIPTION
Update needed so we can upgrade Bonnie ruby version from 2.3.8, as it will EOL soon.

See Bonnie PR: https://github.com/projecttacoma/bonnie/pull/1169

Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1879
- [x] Internal ticket links back to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.

**Cypress Reviewer:**
 
Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
 
**Bonnie Reviewer:**
 
Name: @hossenlopp
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code. *Not sure how I could. All rest client usage is in bonnie_bundler now*
