### PR TITLE
Ratio observations

### DIFF
--- a/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
+++ b/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
@@ -46,7 +46,6 @@ module HQMF2CQL
           # Get the name of the parameter to the  observation function within the measurePopulationCriteria section
           cql_define_function[:parameter] = @doc.at_xpath("cda:QualityMeasureDocument/cda:component/cda:populationCriteriaSection/cda:component/cda:#{measure_population_name}Criteria/cda:id[@root = \"#{measure_population_id}\"]/../cda:precondition/cda:criteriaReference/cda:id").attributes['extension'].value.match('\\"([A-Za-z0-9 ]+)\\"')[1]
 
-
           @observations << cql_define_function
         end
       end

--- a/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
+++ b/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
@@ -42,8 +42,10 @@ module HQMF2CQL
           cql_define_function[:function_name] = entry.at_xpath("*/cda:measureObservationDefinition/cda:value/cda:expression").values.first.match('\\"([A-Za-z0-9 ]+)\\"')[1]
           # The criteria_reference_id is the id of the measurePopulationCriteria that should be used for this observation function
           measure_population_id = entry.at_xpath("*/cda:measureObservationDefinition/cda:component/cda:criteriaReference/cda:id").attributes['root'].value
+          measure_population_name = entry.at_xpath("*/cda:measureObservationDefinition/cda:component/cda:criteriaReference/cda:id").attributes['extension'].value
           # Get the name of the parameter to the  observation function within the measurePopulationCriteria section
-          cql_define_function[:parameter] = @doc.at_xpath("cda:QualityMeasureDocument/cda:component/cda:populationCriteriaSection/cda:component/cda:measurePopulationCriteria/cda:id[@root = \"#{measure_population_id}\"]/../cda:precondition/cda:criteriaReference/cda:id").attributes['extension'].value.match('\\"([A-Za-z0-9 ]+)\\"')[1]
+          cql_define_function[:parameter] = @doc.at_xpath("cda:QualityMeasureDocument/cda:component/cda:populationCriteriaSection/cda:component/cda:#{measure_population_name}Criteria/cda:id[@root = \"#{measure_population_id}\"]/../cda:precondition/cda:criteriaReference/cda:id").attributes['extension'].value.match('\\"([A-Za-z0-9 ]+)\\"')[1]
+
 
           @observations << cql_define_function
         end

--- a/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
+++ b/lib/hqmf-parser/cql/document_helpers/doc_population_helper.rb
@@ -43,7 +43,7 @@ module HQMF2CQL
           # The criteria_reference_id is the id of the measurePopulationCriteria that should be used for this observation function
           measure_population_id = entry.at_xpath("*/cda:measureObservationDefinition/cda:component/cda:criteriaReference/cda:id").attributes['root'].value
           measure_population_name = entry.at_xpath("*/cda:measureObservationDefinition/cda:component/cda:criteriaReference/cda:id").attributes['extension'].value
-          # Get the name of the parameter to the  observation function within the measurePopulationCriteria section
+          # Get the name of the parameter to the observation function within the relevant population criteria section
           cql_define_function[:parameter] = @doc.at_xpath("cda:QualityMeasureDocument/cda:component/cda:populationCriteriaSection/cda:component/cda:#{measure_population_name}Criteria/cda:id[@root = \"#{measure_population_id}\"]/../cda:precondition/cda:criteriaReference/cda:id").attributes['extension'].value.match('\\"([A-Za-z0-9 ]+)\\"')[1]
 
           @observations << cql_define_function


### PR DESCRIPTION
Use measure population name in finding population criteria section for observation function. EG: `<numeratorCriteria classCode="OBS" moodCode="EVN">` will use numeratorCriteria in xpath,
` <measurePopulationCriteria classCode="OBS" moodCode="EVN">` will use measurePopulation in the xpath

Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1947
- [x] Internal ticket links back to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases: N/A
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here:
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here:
 
**Cypress Reviewer:**
 
Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
 
**Bonnie Reviewer:**
 
Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
