### PR TITLE
Author datetime fix

### DIFF
--- a/lib/health-data-standards/models/entry.rb
+++ b/lib/health-data-standards/models/entry.rb
@@ -18,6 +18,7 @@ class Entry
   field :time, type: Integer
   field :start_time, type: Integer
   field :end_time, type: Integer
+  field :author_datetime, type: Integer
   field :status_code, type: Hash
   field :mood_code, type: String, default: "EVN"
   field :negationInd, as: :negation_ind, type: Boolean

--- a/lib/hqmf-model/data_criteria.rb
+++ b/lib/hqmf-model/data_criteria.rb
@@ -36,6 +36,8 @@ module HQMF
               'ANATOMICAL_LOCATION_SITE' => {title:'Anatomical Location Site', coded_entry_method: :anatomical_location,  field_type: :value},
               # ANATOMICAL_STRUCTURE is no longer used.
               'ANATOMICAL_STRUCTURE' => {title:'Anatomical Structure', coded_entry_method: :anatomical_structure, code: '91723000', code_system:'2.16.840.1.113883.6.96', template_id: '2.16.840.1.113883.3.560.1.1000.2', field_type: :value},
+              # AUTHOR DATETIME
+              'AUTHOR_DATETIME' => {title:'Author Date/Time', coded_entry_method: :author_datetime, field_type: :timestamp},
               # Added in QDM 5.4
               'CATEGORY' => {title:'Category', coded_entry_method: :category, field_type: :value},
               'CAUSE' => {title:'Cause', coded_entry_method: :cause_of_death, code: '42752001', code_system:'2.16.840.1.113883.6.96', template_id: '2.16.840.1.113883.3.560.1.1017.2', field_type: :value},

--- a/test/unit/models/entry_test.rb
+++ b/test/unit/models/entry_test.rb
@@ -112,4 +112,8 @@ class EntryTest < Minitest::Test
     entry.cda_identifier = identifier
     assert_equal identifier, entry.identifier
   end
+
+  def test_author_datetime_present
+    assert @entry.respond_to?(:author_datetime)
+  end
 end


### PR DESCRIPTION
Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
Adding Author DateTime field value to entry. There are the two other PRs associated to this task in cql_qdm_patient_api and Bonnie.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1532
- [x] Internal ticket links back to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here:
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here:
 
 **Bonnie Reviewer:**
 
Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
